### PR TITLE
feature - mermaid exporter

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = */venv/*, */.venv/*, */tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Cache pip dependencies
       uses: actions/cache@v2
       with:
@@ -27,4 +27,4 @@ jobs:
     - name: Test Coverage
       run: make coverage
     - name: Code Analysis
-      run: make analyze
+      run: make lint 

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,20 @@
+inherits:
+  - default
+
+strictness: high
+
+max-line-length: 120
+
+test-warnings: true
+
+ignore-paths:
+  - build
+  - dist
+
+pylint:
+  disable:
+    - logging-format-interpolation  # prefer modern f strings
+    - misplaced-comparison-constant # prefer "yoda conditions"
+    - no-else-return                # prefer multiple return statements
+    - redefined-outer-name          # pytest fixture
+  source-roots: .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	@pytest
 
 coverage:
-	@pytest --cov --cov-fail-under=70 --cov-config ../.coveragerc
+	@pytest --cov --cov-fail-under=75 --cov-config .coveragerc
 
 lint:
 	@prospector --profile .prospector.yaml $(filter-out $@,$(MAKECMDGOALS))

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ coverage:
 	@pytest --cov --cov-fail-under=70 --cov-config ../.coveragerc
 
 lint:
-	@prospector --profile ../.prospector.yaml $(filter-out $@,$(MAKECMDGOALS))
+	@prospector --profile .prospector.yaml $(filter-out $@,$(MAKECMDGOALS))

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,3 @@
-### ACTIVE
-* [~] FEATURE - export mermaid
-
 ### OSS RELEASE FOLLOW UPS
 * [ ] code
   * [ ] astrolabe CI/CD move to github
@@ -18,6 +15,7 @@
 * [ ] cannot save nodes with no address or alias (used to be able to save nodes with protocol_mux only, this died during the neo4j refactor)
 
 ### FEATURES/IMPROVEMENTS
+* [x] FEATURE - export mermaid (NOV 2024)
 * [ ] UNKNOWN platdb node type!
 * [ ] Rename discover/profile?
   * [ ] rename ProfileStrategy -> RemoteDiscoveryScript
@@ -29,6 +27,7 @@
 * [ ] Providers
   * [ ] c7n provider
  * [ ] ProfileStrategy::childProviders: rewrite provider lookup to be a shotgun approach instead of configured?
+ * [ ] EXPORTERS: optionally export entire graph or just tree from passed in seeds 
 
 ### REFACTORS/TESTS
 * [ ] `node.py`: remove Node.children field (should be unused logically - cruft remains mainly in tests)

--- a/astrolabe/main.py
+++ b/astrolabe/main.py
@@ -203,4 +203,3 @@ def _set_debug_level():
         return
     if hasattr(constants.ARGS, 'quiet') and not constants.ARGS.quiet:
         logs.logger.setLevel(logging.INFO)
-

--- a/astrolabe/plugins/export_graphviz.py
+++ b/astrolabe/plugins/export_graphviz.py
@@ -8,7 +8,7 @@ License:
 SPDX-License-Identifier: Apache-2.0
 
 System Requirements:
-- requires system installation of graphviz package
+- requires system installation of `graphviz` package (brew install graphviz)
 """
 
 from typing import Dict

--- a/astrolabe/plugins/export_mermaid.py
+++ b/astrolabe/plugins/export_mermaid.py
@@ -1,0 +1,207 @@
+"""
+Module Name: export_mermaid
+
+Description:
+Exports to mermaid
+
+License:
+SPDX-License-Identifier: Apache-2.0
+
+System Requirements:
+- requires system installation of `mmdc` package (npm install -g @mermaid-js/mermaid-cli)
+"""
+import os
+import subprocess
+from typing import Dict
+from astrolabe import constants, database, exporters
+from astrolabe.node import Node
+
+# Global variables to keep track of nodes and edges
+nodes_compiled = []
+edges_compiled = []
+
+
+class MermaidGraph:
+    def __init__(self, direction='auto'):
+        self.direction = direction
+        self.mermaid_lines = []
+
+    def add_node(self, node_name: str, database=False, container=False, node_classes: list = None):
+        """
+        Adds a node to the mermaid graph.
+        """
+        if node_classes is None:
+            node_classes = []
+
+        if database:
+            node_str = f"    {node_name}[({node_name})]"
+        elif container:
+            node_str = f"    {node_name}{{{{{node_name}}}}}"
+        else:
+            node_str = f"    {node_name}[{node_name}]"
+
+        self.mermaid_lines.append(node_str)
+        for node_class in node_classes:
+            self.mermaid_lines.append(f"    class {node_name} {node_class}")
+
+    def add_edge(self, from_node: str, to_node: str, label: str = ''):
+        """
+        Adds an edge between two nodes with an optional label.
+        """
+        arrow = "-->" if not label else f"--{label}-->"
+        edge_str = f"    {from_node} {arrow} {to_node}"
+
+        self.mermaid_lines.append(edge_str)
+
+    def generate(self):
+        """
+        Returns the generated Mermaid code as a string.
+        """
+        direction = self.direction
+        if direction == 'auto':
+            direction = 'TD'  # Automatically choose the top-to-bottom layout as default
+
+        # Initialize flowchart with direction
+        mermaid_code = [f"graph {direction}"]
+
+        # Add styling (if any)
+        mermaid_code.extend([
+            "    classDef error stroke:#f00",
+            "    classDef warning stroke:#f90",
+            "    classDef defunct stroke-dasharray:5",
+        ])
+
+        # Add all lines
+        mermaid_code.extend(self.mermaid_lines)
+        return "\n".join(mermaid_code)
+
+
+class ExporterMermaid(exporters.ExporterInterface):
+    @staticmethod
+    def ref() -> str:
+        return 'mermaid'
+
+    @staticmethod
+    def register_cli_args(argparser: exporters.ExporterArgParser):
+        argparser.add_argument('--direction',
+                               choices=['LR', 'TB', 'auto'],
+                               default='auto',
+                               help='Layout direction for mermaid diagram. '
+                                    "LR = Left-to-Right, "
+                                    "TB = Top-to-Bottom, "
+                                    "auto = automatically chooses the best direction")
+
+    def export(self, tree: Dict[str, Node]):
+        mermaid_graph = MermaidGraph(direction=constants.ARGS.export_mermaid_direction)
+        compile_mermaid_diagram(tree, mermaid_graph)
+
+        # Get the generated Mermaid code
+        mermaid_code = mermaid_graph.generate()
+
+        # Create the filename based on the seed names or default seeds
+        seed_names = ','.join([node.service_name for node in tree.values() if node.service_name is not None])
+        seeds = seed_names or ','.join(constants.ARGS.seeds).replace('.', '-')
+
+        # Define the path where the Mermaid file will be saved
+        output_mermaid_file_path = os.path.join(constants.OUTPUTS_DIR, f"astromaid_{seeds}.mmd")
+
+        # Write the Mermaid code to the output file
+        with open(output_mermaid_file_path, 'w', encoding='utf8') as mermaid_file:
+            mermaid_file.write(mermaid_code)
+
+        # Generate PNG using mmdc
+        output_image_path = os.path.join(constants.OUTPUTS_DIR, f"astromaid_{seeds}.svg")
+        # pylint:disable=subprocess-run-check
+        subprocess.run(["mmdc", "-i", output_mermaid_file_path, "-o", output_image_path])
+
+        # Open the PNG file using qlmanage
+        # pylint:disable=subprocess-run-check
+        subprocess.run(["qlmanage", "-p", output_image_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+class ExporterMermaidSource(exporters.ExporterInterface):
+    @staticmethod
+    def ref() -> str:
+        return 'mermaid_source'
+
+    def export(self, tree: Dict[str, Node]):
+        mermaid_graph = MermaidGraph(direction=constants.ARGS.export_mermaid_direction)
+        compile_mermaid_diagram(tree, mermaid_graph)
+
+        # Get the generated Mermaid code
+        mermaid_code = mermaid_graph.generate()
+
+        # Output the Mermaid source code
+        print(mermaid_code)
+
+    @staticmethod
+    def register_cli_args(argparser: exporters.ExporterArgParser):
+        argparser.add_argument('--direction',
+                               choices=['LR', 'TB', 'auto'],
+                               default='auto',
+                               help='Layout direction for mermaid diagram. '
+                                    "LR = Left-to-Right, "
+                                    "TB = Top-to-Bottom, "
+                                    "auto = automatically chooses the best direction")
+
+
+def compile_mermaid_diagram(tree: Dict[str, Node], mermaid_graph: MermaidGraph) -> None:
+    """
+    Export tree in Mermaid format. Will write an image file to disk and then open it.
+    Optionally, output as Mermaid source code instead of PNG.
+
+    :param tree: The tree to export (services and nodes)
+    :param mermaid_graph: The MermaidGraph instance used to generate the code
+    :param source: If True, export the Mermaid code as source, not as PNG
+    :return: None
+    """
+    nodes_compiled.clear()
+    edges_compiled.clear()
+
+    # Export nodes and connections
+    for node_ref, node in tree.items():
+        _compile_flowchart(node_ref, node, mermaid_graph)
+
+
+def _compile_flowchart(node_ref: str, node: Node, mermaid_graph: MermaidGraph) -> None:
+    node_name = _node_name(node, node_ref)
+    _compile_node(node, node_name, mermaid_graph)
+
+    children = database.get_connections(node)
+    if len(children) > 0:
+        merged_children = exporters.merge_hints(children)
+        for child_ref, child in merged_children.items():
+            if child.warnings.get('DEFUNCT') and constants.ARGS.hide_defunct:
+                continue
+
+            child_name = _node_name(child, child_ref)
+
+            _compile_node(child, child_name, mermaid_graph)
+            _compile_edge(node_name, child_name, child.protocol.ref, mermaid_graph)
+            _compile_flowchart(child_ref, child, mermaid_graph)
+
+
+def _compile_edge(parent_name: str, child_name: str, label: str, mermaid_graph: MermaidGraph) -> None:
+    edge_str = f"{parent_name}.{label}.{child_name}"
+    if edge_str not in edges_compiled:
+        mermaid_graph.add_edge(parent_name, child_name, label)
+        edges_compiled.append(edge_str)
+
+
+def _compile_node(node: Node, name: str, mermaid_graph: MermaidGraph) -> None:
+    if name not in nodes_compiled:
+        node_classes = []
+        if node.errors:
+            node_classes.append("error")
+        if node.warnings:
+            node_classes.append("warning")
+
+        mermaid_graph.add_node(name, node.is_database(), node.containerized, node_classes)
+        nodes_compiled.append(name)
+
+
+def _node_name(node: Node, node_ref: str) -> str:
+    name = node.service_name or f"UNKNOWN{node_ref}"
+    clean_name = exporters.clean_service_name(name)
+    clean_name = f"{clean_name}-{node.provider}"
+    return clean_name

--- a/tests/_fake_database.py
+++ b/tests/_fake_database.py
@@ -61,7 +61,8 @@ def connect_nodes(node1: Node, node2: Node):
         children = {}
         _node_connections[parent_key] = children
     children = _node_connections[parent_key]
-    child_key = f"{node2.provider}:{node2.address}:{node2.protocol_mux}"
+    child_key = node2.address if node2.address else ",".join(node2.aliases)  # this mimic real database
+    # child_key = f"{node2.provider}:{node2.address}:{node2.protocol.ref}:{node2.protocol_mux}:{node2.from_hint}"
     children[child_key] = node2
 
 

--- a/tests/plugins/test_export_ascii.py
+++ b/tests/plugins/test_export_ascii.py
@@ -221,7 +221,7 @@ async def test_export_tree_case_merged_nodes(tree_stubbed_with_child, capsys):
     # arrange
     seed = tree_stubbed_with_child[list(tree_stubbed_with_child)[0]]
     child = list(_fake_database.get_connections(seed).values())[0]
-    redundant_child = replace(child, protocol_mux='some_other_mux')
+    redundant_child = replace(child, address='asdf-zxc', protocol_mux='some_other_mux')
     _fake_database.connect_nodes(seed, redundant_child)
     # - we have to capture this now because export_tree will mutate these objects!
     expected_merged_mux = f"{child.protocol_mux},{redundant_child.protocol_mux}"
@@ -290,8 +290,11 @@ async def test_export_tree_case_merged_nodes(tree_stubbed_with_child, capsys):
 #     child_3.protocol_mux = protocol_mux_2
 #     child_3.set_profile_timestamp()
 #
-#     list(tree_named.values())[0].children = {'child1': child_1, 'child2': child_2, 'child3': child_3}
-#     list(tree_named.values())[0].set_profile_timestamp()
+#     parent_node = list(tree_named.values())[0]
+#     _fake_database.connect_nodes(parent_node, child_1)
+#     _fake_database.connect_nodes(parent_node, child_2)
+#     _fake_database.connect_nodes(parent_node, child_3)
+#     parent_node.set_profile_timestamp()
 #
 #     # act
 #     await _helper_export_tree_with_timeout(tree_named)

--- a/tests/plugins/test_export_mermaid.py
+++ b/tests/plugins/test_export_mermaid.py
@@ -1,0 +1,177 @@
+from dataclasses import replace
+
+import pytest
+
+from astrolabe.plugins import export_mermaid
+from astrolabe.plugins.export_mermaid import MERMAID_LR, MERMAID_TB, MERMAID_AUTO
+from tests import _fake_database
+
+
+@pytest.fixture(autouse=True)
+def patch_database_autouse(patch_database):  # pylint:disable=unused-argument
+    pass
+
+
+@pytest.fixture(autouse=True)
+def set_default_cli_args(cli_args_mock):
+    cli_args_mock.debug = False
+    cli_args_mock.export_mermaid_direction = MERMAID_AUTO
+
+
+@pytest.mark.parametrize('direction', [MERMAID_LR, MERMAID_TB])
+def test_export_tree_case_respect_cli_direction(cli_args_mock, direction, tree_stubbed):
+    # arrange
+    cli_args_mock.export_mermaid_direction = direction
+
+    # act
+    output = export_mermaid.export_tree(tree_stubbed)
+    output_lines = output.splitlines()
+
+    # assert
+    assert f"graph {direction}" in output_lines
+
+
+def test_export_tree_case_respect_cli_direction_auto(cli_args_mock, tree_stubbed):
+    # arrange
+    cli_args_mock.export_mermaid_direction = MERMAID_AUTO
+
+    # act
+    output = export_mermaid.export_tree(tree_stubbed)
+    output_lines = output.splitlines()
+
+    # assert
+    assert f"graph {MERMAID_TB}" in output_lines
+
+
+def test_export_tree_case_node_has_service_name(tree_named):
+    """single node - not from hint, with service name, no children, no errs/warns"""
+    # arrange
+    node = tree_named[list(tree_named)[0]]
+    node.set_profile_timestamp()
+    node_id = f"{node.service_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_named).splitlines()
+
+    # assert
+    assert f"    {node_id}[{node_id}]" in output_lines
+
+
+def test_export_tree_case_node_no_service_name(tree):
+    """single node - not from hint, no service name, no children, no errs/warns"""
+    # arrange
+    node = tree[list(tree)[0]]
+    node_id = f"UNKNOWN-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree).splitlines()
+
+    # assert
+    assert f"    {node_id}[{node_id}]" in output_lines
+
+
+def test_export_tree_case_node_is_database(tree_named):
+    """Database node exported as such"""
+    # arrange
+    node = list(tree_named.values())[0]
+    node.protocol = replace(node.protocol, is_database=True)
+    node_id = f"{node.service_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_named).splitlines()
+
+    # assert
+    assert f"    {node_id}[({node_id})]" in output_lines
+
+
+def test_export_tree_case_node_is_containerized(tree_named):
+    """Containerized node exported as such"""
+    # arrange
+    node = list(tree_named.values())[0]
+    node.containerized = True
+    node_id = f"{node.service_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_named).splitlines()
+
+    # assert
+    assert f"    {node_id}" + "{{" + node_id + "}}" in output_lines
+
+
+def test_export_tree_case_node_warns(tree_named):
+    """Node with warnings exported as such"""
+    # arrange
+    node = list(tree_named.values())[0]
+    node.warnings = {'FOO': True}
+    node_id = f"{node.service_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_named).splitlines()
+
+    # assert
+    assert f"    class {node_id} warning" in output_lines
+
+
+def test_export_tree_case_node_errors(tree_named):
+    """Node with errors exported as such"""
+    # arrange
+    node = list(tree_named.values())[0]
+    node.errors = {'FOO': True}
+    node_id = f"{node.service_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_named).splitlines()
+
+    # assert
+    assert f"    class {node_id} error" in output_lines
+
+
+def test_export_tree_case_node_defunct(tree_named):
+    """Node with errors exported as such"""
+    # arrange
+    node = list(tree_named.values())[0]
+    node.warnings = {'DEFUNCT': True}
+    node_id = f"{node.service_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_named).splitlines()
+
+    # assert
+    assert f"    class {node_id} defunct" in output_lines
+
+
+def test_export_tree_case_node_name_cleaned(tree):
+    """Test that the node name is cleaned during export"""
+    # arrange
+    node = list(tree.values())[0]
+    node.service_name = '"foo:bar#baz"'
+    cleaned_name = "foo_bar_baz"
+    node_id = f"{cleaned_name}-{node.provider}"
+
+    # act
+    output_lines = export_mermaid.export_tree(tree).splitlines()
+
+    # assert
+    node_line = next((line for line in output_lines if cleaned_name in line), None)
+    assert node_line is not None
+    assert node_line.lstrip().startswith(f"{node_id}")
+
+
+@pytest.mark.parametrize('blocking', (True, False))
+def test_export_tree_case_edge_blocking_child(tree_stubbed_with_child, dummy_protocol_ref, blocking):
+    """Validate blocking child shows regular nondashed, non-bold line when it is not blocking from top"""
+    # arrange
+    parent = list(tree_stubbed_with_child.values())[0]
+    child = list(_fake_database.get_connections(parent).values())[0]
+    child.protocol = replace(child.protocol, blocking=blocking)
+
+    # act
+    output_lines = export_mermaid.export_tree(tree_stubbed_with_child).splitlines()
+    edge_line = next((line for line in output_lines if '>' in line), None)
+
+    # assert
+    assert edge_line is not None
+    if blocking:
+        assert f"--{dummy_protocol_ref}-->" in edge_line
+    else:
+        assert f"-.{dummy_protocol_ref}.->" in edge_line


### PR DESCRIPTION
It's cool.  It will create the mermaid source file and print it.  Or it will print it and render it depending on the exporter.  Had to create our own Mermaid rendering class because surprised to find that no good decent basic one existed out there for python!

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/4a95049e-8404-48f8-a8d7-09f90b3dd196">

or this
```
$ astrolabe export -o mermaid_source
Hello, etherops
graph TB
    classDef error stroke:#f00
    classDef warning stroke:#f90
    classDef defunct stroke-dasharray:5
    pynapple1-k8s{{pynapple1-k8s}}
    UNKNOWN-k8s{{UNKNOWN-k8s}}
    class UNKNOWN-k8s warning
    pynapple1-k8s --TCP--> UNKNOWN-k8s
    sandbox1-pynapple1-cache-aws[(sandbox1-pynapple1-cache-aws)]
    pynapple1-k8s --TCP--> sandbox1-pynapple1-cache-aws
    sandbox1-pynapple1-db-aws[(sandbox1-pynapple1-db-aws)]
    pynapple1-k8s --TCP--> sandbox1-pynapple1-db-aws
    sandbox1-pynapple2-aws[sandbox1-pynapple2-aws]
    pynapple1-k8s --TCP--> sandbox1-pynapple2-aws
    sandbox1-pynapple2-20240403223052785000000003-aws[sandbox1-pynapple2-20240403223052785000000003-aws]
    sandbox1-pynapple2-aws --TCP--> sandbox1-pynapple2-20240403223052785000000003-aws
    pynapple2-ssh[pynapple2-ssh]
    sandbox1-pynapple2-20240403223052785000000003-aws --SEED--> pynapple2-ssh
    sandbox1-pynapple2-db-aws[(sandbox1-pynapple2-db-aws)]
    pynapple2-ssh --TCP--> sandbox1-pynapple2-db-aws
    sandbox1-pynapple2-cache-aws[(sandbox1-pynapple2-cache-aws)]
    pynapple2-ssh --TCP--> sandbox1-pynapple2-cache-aws
    pynapple2-k8s{{pynapple2-k8s}}
    pynapple2-k8s --TCP--> sandbox1-pynapple2-db-aws
    pynapple2-k8s --TCP--> sandbox1-pynapple2-cache-aws
    pynapple1-ssh[pynapple1-ssh]
    pynapple1-ssh --TCP--> UNKNOWN-k8s
    pynapple1-ssh --TCP--> sandbox1-pynapple1-cache-aws
    pynapple1-ssh --TCP--> sandbox1-pynapple1-db-aws
    pynapple1-ssh --TCP--> sandbox1-pynapple2-aws

Goodbye, etherops

```

