### PR TITLE
Model Refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Cache pip dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ cython_debug/
 outputs/
 .lastrun.json
 examples/pynapple.astrolabe.conf
+examples/pynapple-curl.sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	@pytest tests
 
 coverage:
-	@pytest --cov --cov-fail-under=75 --cov-config .coveragerc
+	@pytest tests --cov --cov-fail-under=75 --cov-config .coveragerc
 
 lint:
 	@prospector --profile .prospector.yaml $(filter-out $@,$(MAKECMDGOALS))

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKER_COMPOSE=docker-compose \
 	-f tests_integration/neo4j_ephemeral_db/docker-compose.yml
 
 test:
-	@pytest
+	@pytest tests
 
 coverage:
 	@pytest --cov --cov-fail-under=75 --cov-config .coveragerc

--- a/astrolabe.d/Notstat.yaml
+++ b/astrolabe.d/Notstat.yaml
@@ -6,66 +6,91 @@ providers: ["ssh", "k8s"]
 protocol: "TCP"
 providerArgs:
     shell_command: |
-        # pre-requisties
-        # if netstat is installed - let the Netstat profile strategy handle profiling because notstat is SLOW!
+        # pre-requisites
+        # if netstat is installed - let the Netstat profile strategy handle profiling
         which netstat >/dev/null && exit
-
-        notstat() {
-            iterations=${1:-10}  # Number of iterations to sample, default to 10 if not provided
-
-            echo "Proto Recv-Q Send-Q Local_Address Foreign_Address State"
-
-            for ((i=0; i<iterations; i++)); do
-                cat /proc/net/tcp | awk 'NR>1 { print $2, $3, $4, $5, $6 }' | while read local rem state tx_rx queues; do
-                    local_ip_hex=$(echo $local | cut -d: -f1)
-                    local_port_hex=$(echo $local | cut -d: -f2)
-                    rem_ip_hex=$(echo $rem | cut -d: -f1)
-                    rem_port_hex=$(echo $rem | cut -d: -f2)
-
-                    # Convert hex IP to decimal IP
-                    local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$local_ip_hex" | cut -c7-8)" 0x"$(echo "$local_ip_hex" | cut -c5-6)" 0x"$(echo "$local_ip_hex" | cut -c3-4)" 0x"$(echo "$local_ip_hex" | cut -c1-2)")
-                    rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$rem_ip_hex" | cut -c7-8)" 0x"$(echo "$rem_ip_hex" | cut -c5-6)" 0x"$(echo "$rem_ip_hex" | cut -c3-4)" 0x"$(echo "$rem_ip_hex" | cut -c1-2)")
-
-                    # Convert hex port to decimal port
-                    local_port_dec=$(printf "%d\n" 0x$local_port_hex)
-                    rem_port_dec=$(printf "%d\n" 0x$rem_port_hex)
-
-                    # Split tx_queue and rx_queue
-                    tx_queue=$(echo "$tx_rx" | awk -F: '{print $1}')
-                    rx_queue=$(echo "$tx_rx" | awk -F: '{print $2}')
-
-                    # Convert hex queues to decimal
-                    tx_queue_dec=$(printf "%d\n" 0x$tx_queue)
-                    rx_queue_dec=$(printf "%d\n" 0x$rx_queue)
-
-                    # Decode the connection state
-                    case "$state" in
-                        "01") state_dec="EST" ;;
-                        "0A") state_dec="LISTEN" ;;
-                        *) state_dec="OTHER" ;;
-                    esac
-
-                    echo "tcp $rx_queue_dec $tx_queue_dec $local_ip_dec:$local_port_dec $rem_ip_dec:$rem_port_dec $state_dec"
-                done
-                sleep 0.1
+        
+        # Function to sample /proc/net/tcp for a specified duration
+        # Capturing only the essential information for connection identification
+        sample_connections() {
+            local duration=${1:-3}  # Duration in seconds to sample, default to 3 seconds
+            local output_file=$2
+            local start_time=$(date +%s)
+            local end_time=$((start_time + duration))
+            
+            echo "Sampling /proc/net/tcp for ${duration} seconds..."
+            
+            # Create empty output file
+            > "$output_file"
+            
+            # Sample connections until the duration is reached
+            while [ $(date +%s) -lt $end_time ]; do
+                # Only grab local address, remote address, and state (columns 2, 3, 4)
+                awk 'NR>1 {print $2, $3, $4}' /proc/net/tcp >> "$output_file"
             done
         }
         
+        # Function to process and format connections
+        notstat() {
+            local duration=${1:-3}  # Duration in seconds to sample, default to 3 seconds
+            local temp_dir=$(mktemp -d)
+            local raw_file="$temp_dir/raw_connections"
+            local unique_file="$temp_dir/unique_connections"
+            
+            # Sample connections
+            sample_connections "$duration" "$raw_file"
+            
+            # Get unique connections only
+            sort -u "$raw_file" > "$unique_file"
+            
+            echo "Local_Address Foreign_Address State"
+            
+            # Process only the unique connections
+            while read local rem state; do
+                local_ip_hex=$(echo $local | cut -d: -f1)
+                local_port_hex=$(echo $local | cut -d: -f2)
+                rem_ip_hex=$(echo $rem | cut -d: -f1)
+                rem_port_hex=$(echo $rem | cut -d: -f2)
+        
+                # Convert hex IP to decimal IP
+                local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$local_ip_hex" | cut -c7-8)" 0x"$(echo "$local_ip_hex" | cut -c5-6)" 0x"$(echo "$local_ip_hex" | cut -c3-4)" 0x"$(echo "$local_ip_hex" | cut -c1-2)")
+                rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$rem_ip_hex" | cut -c7-8)" 0x"$(echo "$rem_ip_hex" | cut -c5-6)" 0x"$(echo "$rem_ip_hex" | cut -c3-4)" 0x"$(echo "$rem_ip_hex" | cut -c1-2)")
+        
+                # Convert hex port to decimal port
+                local_port_dec=$(printf "%d\n" 0x$local_port_hex)
+                rem_port_dec=$(printf "%d\n" 0x$rem_port_hex)
+        
+                # Decode the connection state
+                case "$state" in
+                    "01") state_dec="EST" ;;
+                    "0A") state_dec="LISTEN" ;;
+                    *) state_dec="OTHER" ;;
+                esac
+        
+                echo "$local_ip_dec:$local_port_dec $rem_ip_dec:$rem_port_dec $state_dec"
+            done < "$unique_file"
+            
+            # Clean up temp files
+            rm -rf "$temp_dir"
+        }
+        
+        # Run notstat to gather data (adjust duration as needed)
+        ALL_CONNECTIONS=$(notstat 3)
+        
         # determine listening ports on this instance
-        listening_ports=$(notstat | grep LISTEN | awk '{print $4}' | awk -F: '{print $NF}' | grep '[0-9]' | sort | uniq | paste -sd "|" -)
-
-        # get connections on ports we are interested in
-        notstat | sort -u | awk '$5 ~ /:(3306|9042|9160|11211|5432|6379|80)$/ {print}' |
-
-        # filter TCP responses - we only want originating requests this filters out HTTP server response to
-        # clients on ephemeral ports which happen to be in our list of ports of interest
-        awk '$4 !~ /:('"$listening_ports"')$/ {print $5}' |
-
-        # exclude if self is the dest
-        grep -v $(hostname -i) |
-
-        # only take 1 server per port
-        tr ':' ' ' | sort -k2 | uniq | awk 'BEGIN{print "mux address"};$1$2!=uniqid{print $2,$1;uniqie=$1$2}'
+        LISTENING_PORTS=$(echo "$ALL_CONNECTIONS" | grep LISTEN | awk '{print $1}' | awk -F: '{print $NF}' | grep '[0-9]' | sort | uniq | paste -sd "|" -)
+        
+        # Process the data in one go
+        echo "$ALL_CONNECTIONS" | 
+            # get connections on ports we are interested in
+            awk '$2 ~ /:(3306|9042|9160|11211|5432|6379|80)$/ {print}' |
+            # filter TCP responses - we only want originating requests
+            awk '$1 !~ /:('"$LISTENING_PORTS"')$/ {print $2}' |
+            # exclude if self is the dest
+            grep -v $(hostname -i) |
+            # only take 1 server per port
+            tr ':' ' ' | sort -k2 | uniq | 
+            awk 'BEGIN{print "mux address"};$1$2!=uniqid{print $2,$1;uniqid=$1$2}'
 childProvider:
     type: "matchPort"
     matches:

--- a/astrolabe/cli_args.py
+++ b/astrolabe/cli_args.py
@@ -70,7 +70,9 @@ def parse_args(registered_exporter_refs: List[str]) -> (configargparse.Namespace
                             help='Seed host(s) to begin discovering viz. an IP address or hostname.  '
                                  'Must be in the format: "provider:address".  '
                                  'e.g. "ssh:10.0.0.42" or "k8s:widget-machine-5b5bc8f67f-2qmkp')
-    discover_p.add_argument('-t', '--timeout', type=int, default=60, metavar='TIMEOUT',
+    discover_p.add_argument('-S', '--seeds-only', action='store_true',
+                            help="Only profile seeds (and not inventoried nodes)")
+    discover_p.add_argument('-t', '--timeout', type=int, default=180, metavar='TIMEOUT',
                             help='Timeout when discovering a node')
     discover_p.add_argument('-d', '--max-depth', type=int, default=100, metavar='DEPTH',
                             help='Max tree depth to discover')

--- a/astrolabe/discover.py
+++ b/astrolabe/discover.py
@@ -47,7 +47,7 @@ class DiscoveryException(Exception):
 
 
 # pylint:disable=too-many-locals
-async def discover(seeds: Dict[str, Node], initial_ancestors: List[str]):  # noqa: C901
+async def discover(seeds: Dict[str, Node], initial_ancestors: List[str]):  # noqa: C901, MC0001
     global discovery_ancestors  # pylint:disable=global-variable-not-assigned
     # SEED DATABASE
     for ref, node in seeds.items():
@@ -255,7 +255,7 @@ async def _lookup_service_name(node: Node, provider: providers.ProviderInterface
 
 
 # pylint:disable=too-many-locals
-async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str, Node]:  # noqa: C901
+async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str, Node]:  # noqa: C901, MC0001
     provider_ref = node.provider
     service_name = node.service_name
 

--- a/astrolabe/logs.py
+++ b/astrolabe/logs.py
@@ -13,6 +13,6 @@ import logging
 # logger
 logger = logging.getLogger('astrolabe')
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s %(filename)s.%(funcName)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter('%(asctime)s %(filename)s:%(funcName)s - %(levelname)s - %(message)s')
 handler.setFormatter(formatter)
 logger.addHandler(handler)

--- a/astrolabe/node.py
+++ b/astrolabe/node.py
@@ -44,7 +44,7 @@ class NodeTransport:
     """
     profile_strategy_name: str  # name of profile strategy used to discover node
     provider: str
-    protocol: 'network.Protocol'  # NOQA  (string import for type hint to avoid circular dependency)
+    protocol: 'network.Protocol'  # noqa: F821  # Avoid circular import
     protocol_mux: str
     address: Optional[str] = None
     from_hint: bool = False
@@ -63,7 +63,7 @@ class NodeTransport:
 class Node:
     profile_strategy_name: str  # name of the profile strategy used to determine, for debugging
     provider: str
-    protocol: 'network.Protocol' = None  # NOQA  (string import for type hint to avoid circular dependency)
+    protocol: 'network.Protocol' = None  # noqa: F821  # Avoid circular import
     protocol_mux: str = None
     containerized: bool = False
     from_hint: bool = False

--- a/astrolabe/platdb.py
+++ b/astrolabe/platdb.py
@@ -25,7 +25,8 @@ from neomodel import (
     RelationshipTo,
     StringProperty,
     StructuredNode,
-    db
+    db,
+    Q
 )
 
 from neomodel.properties import Property

--- a/astrolabe/platdb.py
+++ b/astrolabe/platdb.py
@@ -15,19 +15,22 @@ from typing import Any, Optional
 import neo4j
 
 from neo4j import GraphDatabase
-from neomodel import (
+from neomodel import (    # pylint: disable=unused-import
     ArrayProperty,
     DoesNotExist,
     DateTimeProperty,
-    FloatProperty,
     JSONProperty,
     RelationshipFrom,
     RelationshipTo,
     StringProperty,
     StructuredNode,
-    db,
-    Q
+    ZeroOrOne,
+    ZeroOrMore,
+    db
 )
+
+# Q is required for neomodel queries to work correctly, even if not directly referenced in this file
+from neomodel import Q  # noqa: F401 pylint: disable=unused-import
 
 from neomodel.properties import Property
 
@@ -182,6 +185,7 @@ class PlatDBNode(StructuredNode):
 
 class PlatDBDNSNode(PlatDBNode):
     __abstract_node__ = True
+    address = StringProperty(unique_index=True, null=True, required=False)
     dns_names = ArrayProperty(StringProperty(), unique_index=True, null=True)
 
     # pylint:disable=arguments-differ
@@ -230,102 +234,56 @@ class PlatDBDNSNode(PlatDBNode):
         return [existing_resource]
 
 
+class PlatDBNetworkNode(PlatDBNode):
+    __abstract_node__ = True
+    """Base class for nodes with network properties."""
+    name = StringProperty()
+    address = StringProperty(required=True)
+    protocol = StringProperty()
+    protocol_multiplexor = StringProperty()
+
+
 class Application(PlatDBNode):
     name = StringProperty(unique_index=True)
 
-    application_to = RelationshipTo('Application', 'CALLS')
-    application_from = RelationshipFrom('Application', 'CALLED_BY')
-    compute = RelationshipFrom('Compute', 'RUNS')
-    egress_controller = RelationshipTo('EgressController', 'DEPENDS_ON')
-    insights = RelationshipFrom('Insights', 'APPLIES_TO')
-    repo = RelationshipFrom('Repo', 'STORES')
-    resources = RelationshipTo('Resource', 'USES')
-    traffic_controllers = RelationshipTo('TrafficController', 'DEPENDS_ON')
+    # Application-Deployment relationships
+    deployments = RelationshipTo('Deployment', 'IMPLEMENTED_BY', cardinality=ZeroOrMore)
 
 
-class CDN(PlatDBNode):
-    name = StringProperty()
-    traffic_controllers = RelationshipTo('TrafficController', 'DEPENDS_ON')
-
-
-class Compute(PlatDBNode):
-    address = StringProperty(required=True)
-
-    platform = StringProperty()
-    protocol = StringProperty()
-    protocol_multiplexor = StringProperty()
-
-    name = StringProperty()
-    compute_to = RelationshipTo('Compute', 'CALLS')
-    compute_from = RelationshipFrom('Compute', 'CALLED_BY')
-    applications = RelationshipTo('Application', 'RUNS')
-    deployments = RelationshipTo('Deployment', 'PROVIDES')
-
-
-class Deployment(PlatDBNode):
+class Deployment(PlatDBNetworkNode):
     name = StringProperty(unique_index=True)
     deployment_type = StringProperty(choices={
-        "auto_scaling_group": "Auto Scaling Group",
-        "target_group": "Target Group",
+        "aws_asg": "AWS Auto Scaling Group",
         "k8s_deployment": "K8s Deployment"})
-    traffic_controllers = RelationshipTo('TrafficController', 'PROVIDES')
-    computes = RelationshipTo('Compute', 'USES')
-    address = StringProperty(required=True)
-    protocol = StringProperty(required=True)
-    protocol_multiplexor = StringProperty(required=True)
-
-
-class EgressController(PlatDBNode):
-    name = StringProperty()
-    applications = RelationshipFrom('Application', 'DEPENDS_ON')
-
-
-class Insights(PlatDBNode):
-    """Assuming id is managed internally by Neo4j as a unique identifier
-    UniqueIdProperty can be used to generate a UUID but isn't a direct 
-    analogue of an auto_increment field. For a direct MySQL 'id' 
-    equivalent, you can use an IntegerProperty and manage it manually.
-    """
-    attribute_name = StringProperty(required=True)
-    recommendation = StringProperty(required=True)
-    starting_state = StringProperty(required=True)
-    upgraded_state = StringProperty(required=True)
-    min_improvement = FloatProperty()
-    max_improvement = FloatProperty()
-    note = StringProperty()
-
-    # Automatically set to current date & time when created
-    created = DateTimeProperty(default_now=True)
-
-    # Automatically updated to current date & time when node is saved
-    updated = DateTimeProperty(default_now=True)
 
     # Relationships
-    applications = RelationshipTo('Application', 'APPLIES_TO')
-
-    def save(self, *args, **kwargs):
-        # Update the 'updated' property to current time when saving
-        self.updated = datetime.datetime.now(datetime.timezone.utc)
-        return super().save(*args, **kwargs)
-
-
-class Repo(PlatDBNode):
-    name = StringProperty()
-    applications = RelationshipTo('Application', 'STORES')
+    application = RelationshipTo('Application', 'IMPLEMENTS', cardinality=ZeroOrOne)
+    computes = RelationshipTo('Compute', 'HAS_MEMBER', cardinality=ZeroOrMore)
+    traffic_controller = RelationshipTo('TrafficController', 'FORWARDED_FROM',
+                                        cardinality=ZeroOrOne)
+    downstream_traffic_ctrls = RelationshipTo('TrafficController', 'CALLS', cardinality=ZeroOrMore)
+    downstream_deployments = RelationshipTo('Deployment', 'CALLS', cardinality=ZeroOrMore)
+    upstream_deployments = RelationshipTo('Deployment', 'CALLED_BY', cardinality=ZeroOrMore)
+    resources = RelationshipTo('Resource', 'CALLS', cardinality=ZeroOrMore)
 
 
-class Resource(PlatDBDNSNode):
-    address = StringProperty(unique_index=True, null=True)
-    applications = RelationshipFrom('Application', 'USED_BY')
-    name = StringProperty()
-    protocol = StringProperty()
-    protocol_multiplexor = StringProperty()
+class Compute(PlatDBNetworkNode):
+    platform = StringProperty()
+
+    # Relationships
+    deployment = RelationshipTo('Deployment', 'MEMBER_OF', cardinality=ZeroOrOne)
+
+    # I Think we need to get rid of or refactor this, and corresponding database.py usages
+    downstream_computes = RelationshipTo('Compute', 'CALLS', cardinality=ZeroOrMore)
+    upstream_computes = RelationshipFrom('Compute', 'CALLED_BY', cardinality=ZeroOrMore)
 
 
-class TrafficController(PlatDBDNSNode):
-    address = StringProperty()
-    applications = RelationshipFrom('Application', 'CALLED_BY')
-    deployments = RelationshipTo('Deployment', 'USED_BY')
-    name = StringProperty(unique_index=True)
-    protocol = StringProperty()
-    protocol_multiplexor = StringProperty()
+class TrafficController(PlatDBDNSNode, PlatDBNetworkNode):
+    # Relationships
+    downstream_deployments = RelationshipTo('Deployment', 'FORWARDS_TO', cardinality=ZeroOrOne)
+    upstream_deployments = RelationshipTo('Deployment', 'CALLED_BY', cardinality=ZeroOrMore)
+
+
+class Resource(PlatDBDNSNode, PlatDBNetworkNode):
+    # Relationships
+    upstreams = RelationshipTo('Deployment', 'CALLED_BY', cardinality=ZeroOrMore)

--- a/astrolabe/plugin_core.py
+++ b/astrolabe/plugin_core.py
@@ -122,3 +122,6 @@ class PluginFamilyRegistry:
 
     def get_registered_plugin_refs(self) -> List[str]:
         return list(self._plugin_registry.keys())
+
+    def get_registered_plugins(self) -> List[PluginInterface]:
+        return list(self._plugin_registry.values())

--- a/astrolabe/plugins/export_ascii.py
+++ b/astrolabe/plugins/export_ascii.py
@@ -216,7 +216,7 @@ def _export_node_errs_warns(node: Node, error_prefix: str, out):
         'CONNECT_SKIPPED': f"service detected on {node.protocol.ref}:{node.protocol_mux}, however name discovery"
                            f"and discovering skipped by configuration!",
         'NULL_ADDRESS': f"service '{node.service_name}' detected but an instance address is not available to discover!",
-        'TIMEOUT': f"SSH timeout connecting to service:'{node.service_name}' at address: '{node.address}'",
+        'TIMEOUT': f"Timeout connecting to service:'{node.service_name}' at address: '{node.address}'",
         'CYCLE': f"service '{node.service_name}' discovered as a parent of itself!",
         'PROFILE_SKIPPED': f"service '{node.service_name}' discovered but discovering skipped by configuration"
     }

--- a/astrolabe/plugins/provider_aws.py
+++ b/astrolabe/plugins/provider_aws.py
@@ -43,6 +43,8 @@ class ProviderAWS(ProviderInterface):
         self.elasticache_client = boto3.client('elasticache')
         self.tag_filters = {tag_filter.split('=')[TAG_NAME_POS]: tag_filter.split('=')[TAG_VALUE_POS]
                             for tag_filter in constants.ARGS.aws_tag_filters}
+
+    async def inventory(self):
         self._inventory_rds()
         self._inventory_elasticache()
         self._inventory_load_balancers()
@@ -163,15 +165,28 @@ class ProviderAWS(ProviderInterface):
                     logs.logger.info("Inventoried 1 AWS ElastiCache node: %s", node.debug_id())
 
     # pylint:disable=too-many-locals,too-many-nested-blocks
-    def _inventory_load_balancers(self):
+    def _inventory_load_balancers(self):  # noqa: C901
         paginator = self.elb_client.get_paginator('describe_load_balancers')
         for page in paginator.paginate():
             for lb in page['LoadBalancers']:  # pylint:disable=invalid-name
                 lb_node = None
                 lb_address = lb['DNSName']
-                name = lb['LoadBalancerName']
+                lb_name = lb['LoadBalancerName']
                 listeners = self.elb_client.describe_listeners(LoadBalancerArn=lb['LoadBalancerArn'])['Listeners']
                 lb_port = listeners[0]['Port'] if listeners else None
+                tags_response = self.elb_client.describe_tags(ResourceArns=[lb['LoadBalancerArn']])
+                if 'TagDescriptions' in tags_response and tags_response['TagDescriptions']:
+                    for tag in tags_response['TagDescriptions'][0]['Tags']:
+                        if tag['Key'] == constants.ARGS.aws_service_name_tag:
+                            lb_app_tag = tag['Value']
+                            break
+                    else:
+                        raise ValueError(
+                            f'Required tag {constants.ARGS.aws_service_name_tag} not configured for AWS LB: {lb_name}')
+                else:
+                    raise ValueError(
+                        f'Required tag {constants.ARGS.aws_service_name_tag} not configured for AWS LB: {lb_name}')
+
                 if not lb_node:  # we only need this once
                     lb_node = Node(
                         node_type=NodeType.TRAFFIC_CONTROLLER,
@@ -179,7 +194,7 @@ class ProviderAWS(ProviderInterface):
                         provider='aws',
                         protocol=PROTOCOL_TCP,
                         protocol_mux=lb_port,
-                        service_name=name,
+                        service_name=lb_app_tag,
                         aliases=[lb_address]
                     )
                     database.save_node(lb_node)
@@ -205,15 +220,14 @@ class ProviderAWS(ProviderInterface):
                             # Create the ASG Node
                             if not asg_node:  # we only need this once
                                 asg_name = asg_instance['AutoScalingGroupName']
-                                asg_address = asg_name
                                 asg_node = Node(
-                                    address=asg_address,
+                                    address=asg_name,
                                     node_type=NodeType.DEPLOYMENT,
                                     profile_strategy_name=INVENTORY_PROFILE_STRATEGY_NAME,
                                     protocol=PROTOCOL_TCP,
                                     protocol_mux=tg_port,
                                     provider='aws',
-                                    service_name=asg_name
+                                    service_name=lb_app_tag
                                 )
                                 asg_nodes[f"ASG_{asg_name}"] = asg_node
                                 database.save_node(asg_node)

--- a/astrolabe/plugins/provider_aws.py
+++ b/astrolabe/plugins/provider_aws.py
@@ -165,7 +165,7 @@ class ProviderAWS(ProviderInterface):
                     logs.logger.info("Inventoried 1 AWS ElastiCache node: %s", node.debug_id())
 
     # pylint:disable=too-many-locals,too-many-nested-blocks
-    def _inventory_load_balancers(self):  # noqa: C901
+    def _inventory_load_balancers(self):  # noqa: C901, MC0001
         paginator = self.elb_client.get_paginator('describe_load_balancers')
         for page in paginator.paginate():
             for lb in page['LoadBalancers']:  # pylint:disable=invalid-name

--- a/astrolabe/plugins/provider_ssh.py
+++ b/astrolabe/plugins/provider_ssh.py
@@ -78,7 +78,7 @@ class ProviderSSH(ProviderInterface):
         logs.logger.debug("Running sidecars for address %s", address)
         await _sidecar_lookup_hostnames(address, connection)
 
-    async def profile(self, address: str, pfss: List[ProfileStrategy], connection: SSHClientConnection)\
+    async def profile(self, node: Node, pfss: List[ProfileStrategy], connection: SSHClientConnection)\
             -> List[NodeTransport]:
         node_transports = []
         for pfs in pfss:
@@ -92,7 +92,7 @@ class ProviderSSH(ProviderInterface):
             if response.stdout.strip().startswith('ERROR:'):
                 raise Exception("CRAWL ERROR: %s" %  # pylint: disable=broad-exception-raised
                                 response.stdout.strip().replace("\n", "\t"))
-            i_node_transports = parse_profile_strategy_response(response.stdout.strip(), address, pfs)
+            i_node_transports = parse_profile_strategy_response(response.stdout.strip(), node.address, pfs)
             node_transports.extend(i_node_transports)
         return node_transports
 

--- a/examples/generate_pynapple_curl.sh
+++ b/examples/generate_pynapple_curl.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Function to retrieve the actual DNS name of the EC2 load balancer for pynapple1
+get_ec2_lb_dns() {
+    # Try classic ELB first
+    local dns=$(aws elb describe-load-balancers \
+        --output text | grep -i pynapple1 | head -n 1 | awk '{print $3}')
+        
+    # If not found, try v2 load balancers (ALB/NLB)
+    if [ -z "$dns" ]; then
+        dns=$(aws elbv2 describe-load-balancers \
+            --output text | grep -i pynapple1 | head -n 1 | awk '{print $4}')
+    fi
+    
+    # If still not found, try listing all load balancers and grep
+    if [ -z "$dns" ]; then
+        echo "Trying detailed search for pynapple1 load balancer..."
+        aws elb describe-load-balancers --output text > /tmp/elbs.txt
+        dns=$(grep -i pynapple1 /tmp/elbs.txt | head -n 1 | awk '{print $3}')
+        
+        if [ -z "$dns" ]; then
+            aws elbv2 describe-load-balancers --output text > /tmp/elbv2s.txt
+            dns=$(grep -i pynapple1 /tmp/elbv2s.txt | head -n 1 | awk '{print $4}')
+        fi
+    fi
+    
+    echo "$dns"
+}
+
+# Function to retrieve the actual DNS name of the K8s service load balancer for pynapple1
+get_k8s_lb_dns() {
+    kubectl get svc -o wide | grep pynapple1 | grep LoadBalancer | awk '{print $4}'
+}
+
+# Get the actual DNS names from the load balancers
+EC2_LB=$(get_ec2_lb_dns)
+K8S_LB=$(get_k8s_lb_dns)
+
+# Check if we got valid DNS names
+if [ -z "$EC2_LB" ]; then
+    echo "Error: Could not find EC2 load balancer for pynapple1"
+    exit 1
+fi
+
+if [ -z "$K8S_LB" ]; then
+    echo "Error: Could not find K8s service load balancer for pynapple1"
+    exit 1
+fi
+
+# Generate the curl command with the actual ELB DNS names
+CURL_CMD="while true; do curl -v http://$EC2_LB/pynapples; echo -e '\n---\n'; curl -v http://$K8S_LB/pynapples; echo -e '\n==========\n'; sleep 5; done"
+
+# Print the command
+echo "Generated curl command:"
+echo "$CURL_CMD"
+
+# Also write to a file for easy execution
+SCRIPT_FILE="$(dirname "$0")/pynapple-curl.sh"
+echo '#!/bin/bash' > "$SCRIPT_FILE"
+echo "$CURL_CMD" >> "$SCRIPT_FILE"
+chmod +x "$SCRIPT_FILE"
+
+echo "Script written to $SCRIPT_FILE. Run it with:"
+echo "./$SCRIPT_FILE"
+
+# Offer to execute the command directly
+echo "Or execute it now? [y/N]"
+read -r response
+if [[ "$response" =~ ^[Yy]$ ]]; then
+    echo "Executing curl command..."
+    eval "$CURL_CMD"
+fi

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'pyyaml~=6.0',
         'graphviz>=0.13',
         'termcolor~=2.0',
+        'neomodel~=5.3',
         'neo4j~=5.19.0',  # neomodel 5.3.1 depends on neo4j~=5.19.0
         'cryptography<43.0.0'  # cryptography warnings: https://github.com/paramiko/paramiko/issues/2419
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def patch_database(mocker):
 def cli_args_mock(mocker):
     args = mocker.patch('astrolabe.constants.ARGS', autospec=True)
     args.max_depth = 100
+    args.seeds_only = False
     return args
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,8 @@
 # pylint: disable=unused-argument,too-many-arguments,too-many-positional-arguments
 
 import datetime
+
+import neomodel
 import pytest
 
 
@@ -64,6 +66,15 @@ def mock_deployment_node(protocol_fixture):
 @pytest.fixture(autouse=True)
 def mock_neo4j_connection_open(mocker):
     return mocker.patch.object(database.platdb.Neo4jConnection, 'open', return_value=None)
+
+
+@pytest.fixture(autouse=True)
+def mock_neo4j_replace(mocker):
+    return mocker.patch.object(neomodel.RelationshipManager, 'replace', return_value=None)
+
+@pytest.fixture(autouse=True)
+def mock_neo4j_connect(mocker):
+    return mocker.patch.object(neomodel.RelationshipManager, 'connect', return_value=None)
 
 
 @pytest.fixture

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -72,6 +72,7 @@ def mock_neo4j_connection_open(mocker):
 def mock_neo4j_replace(mocker):
     return mocker.patch.object(neomodel.RelationshipManager, 'replace', return_value=None)
 
+
 @pytest.fixture(autouse=True)
 def mock_neo4j_connect(mocker):
     return mocker.patch.object(neomodel.RelationshipManager, 'connect', return_value=None)

--- a/tests/test_platdb.py
+++ b/tests/test_platdb.py
@@ -7,27 +7,20 @@
 # DB connection objects that were yielded to the function.
 # pylint: disable=unused-argument
 
-import datetime
-
 import pytest
 
-from neomodel import ZeroOrMore
+from neomodel import ZeroOrMore, ZeroOrOne
 
 from astrolabe.platdb import (PlatDBNode,
                               StructuredNode,
                               Application,
-                              CDN,
                               Compute,
                               Deployment,
-                              EgressController,
-                              Insights,
-                              Repo,
                               Resource,
                               TrafficController)
 
 neo4j_db_fixtures = [
     (Application, {"name": "app1"}, {"name": "new_app1"}),
-    (CDN, {"name": "cdn1"}, {"name": "new_cdn1"}),
     (Compute, {
         "platform": "ec2",
         "address": "1.2.3.4",
@@ -51,19 +44,6 @@ neo4j_db_fixtures = [
         "protocol": "HTTP",
         "protocol_multiplexor": "443"
     }),
-    (EgressController, {"name": "egress1"}, {"name": "new_egress1"}),
-    (Insights, {
-        "attribute_name": "attr1",
-        "recommendation": "recommendation1",
-        "starting_state": "state1",
-        "upgraded_state": "state2"
-    }, {
-        "attribute_name": "new_attr1",
-        "recommendation": "new_recommendation1",
-        "starting_state": "new_state1",
-        "upgraded_state": "new_state2"
-    }),
-    (Repo, {"name": "repo1"}, {"name": "new_repo1"}),
     (Resource, {
         "name": "resource1",
         "address": "1.2.3.4",
@@ -164,28 +144,13 @@ def test_update_object_exists(mocker):
     assert obj.relationship == rel_update
 
 
-def test_insights_save(mocker):
-    # arrange
-    insight = Insights()
-    mocker.patch.object(PlatDBNode, "save")
-
-    # act
-    insight.save()
-
-    # assert
-    assert isinstance(insight.updated, datetime.datetime)
-    assert isinstance(insight.updated.year, int)
-    assert isinstance(insight.updated.month, int)
-    assert isinstance(insight.updated.day, int)
-    assert insight.updated.tzinfo is datetime.timezone.utc
-
-
 @pytest.mark.parametrize('cls,attrs,updated_attrs', neo4j_db_fixtures)
 def test_platdb_node_to_dict_for_all_classes(mocker, cls, attrs, updated_attrs):
     obj = cls(**attrs)
     rel = []
 
     mocker.patch.object(ZeroOrMore, 'all', return_value=rel)
+    mocker.patch.object(ZeroOrOne, 'all', return_value=rel)
 
     platdb_ht = obj.platdbnode_to_dict()
 

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -8,7 +8,8 @@ from neomodel import db
 
 from astrolabe.platdb import (Neo4jConnection,
                               Application,
-                              Compute)
+                              Compute,
+                              Deployment)
 
 
 @pytest.fixture(scope="module")
@@ -44,13 +45,21 @@ def mock_complex_graph(neo4j_connection):
     Applications and Computes are connected based off numbers, 
     so app1 -> compute1 etc. 
     """
+    # Nodes
     app1 = Application(**{'name': 'app1'}).save()
     app2 = Application(**{'name': 'app2'}).save()
     compute1 = Compute(**create_mock_service('compute1')).save()
     compute2 = Compute(**create_mock_service('compute2')).save()
+    deployment1 = Deployment(**{'address': 'addy1'}).save()
+    deployment2 = Deployment(**{'address': 'addy2'}).save()
 
-    compute1.applications.connect(app1)
-    compute2.applications.connect(app2)
+    # Connections
+    deployment1.computes.connect(compute1)
+    compute1.deployment.connect(deployment1)
+    deployment1.application.connect(app1)
+    app1.deployments.connect(deployment1)
 
-    app1.application_to.connect(app2)
-    app1.application_from.connect(app2)
+    deployment2.computes.connect(compute2)
+    compute2.deployment.connect(deployment2)
+    deployment2.application.connect(app2)
+    app2.deployments.connect(deployment2)

--- a/tests_integration/test_platdb_ephemeral.py
+++ b/tests_integration/test_platdb_ephemeral.py
@@ -8,18 +8,13 @@ import pytest
 
 
 from astrolabe.platdb import (Application,
-                              CDN,
                               Compute,
                               Deployment,
-                              EgressController,
-                              Insights,
-                              Repo,
                               Resource,
                               TrafficController)
 
 neo4j_db_fixtures = [
     (Application, {"name": "app1"}, {"name": "new_app1"}),
-    (CDN, {"name": "cdn1"}, {"name": "new_cdn1"}),
     (Compute, {
         "platform": "ec2",
         "address": "1.2.3.4",
@@ -33,29 +28,16 @@ neo4j_db_fixtures = [
         "protocol_multiplexor": "80"
     }),
     (Deployment, {
-        "deployment_type": "auto_scaling_group",
+        "deployment_type": "aws_asg",
         "address": "1.2.3.4",
         "protocol": "TCP",
         "protocol_multiplexor": "80"
     }, {
-        "deployment_type": "target_group",
+        "deployment_type": "k8s_deployment",
         "address": "5.6.7.8",
         "protocol": "HTTP",
         "protocol_multiplexor": "443"
     }),
-    (EgressController, {"name": "egress1"}, {"name": "new_egress1"}),
-    (Insights, {
-        "attribute_name": "attr1",
-        "recommendation": "recommendation1",
-        "starting_state": "state1",
-        "upgraded_state": "state2"
-    }, {
-        "attribute_name": "new_attr1",
-        "recommendation": "new_recommendation1",
-        "starting_state": "new_state1",
-        "upgraded_state": "new_state2"
-    }),
-    (Repo, {"name": "repo1"}, {"name": "new_repo1"}),
     (Resource, {
         "name": "resource1",
         "address": "1.2.3.4",
@@ -136,7 +118,7 @@ def test_get_full_graph_as_json(mocker, mock_complex_graph, neo4j_connection):
     vertices, edges = neo4j_connection.get_full_graph_as_json()
 
     # The number is 4 because that is how many vertices are in mock_complex_graph
-    assert mock_create_platdb_ht.call_count == 4
+    assert mock_create_platdb_ht.call_count == 6
 
     for edge in edges:
         start = edge['start_node']


### PR DESCRIPTION
**Major refactor of model relationships**
<img width="873" alt="image" src="https://github.com/user-attachments/assets/b4dd81d3-ba3f-4961-8292-3d49a2610702" />

Previously - we were losing granularity of what Deployments were connected to what Deployments - since everything was aggregated write-time to the Application.  As an intermediette solution, Application is now dangling from Deployment only - and we preserve the Deployment-Deployment connection.  

We will try to represent Application connections as was done previously virtually query-side.  If this isn't sufficient, we will also go back and add the Application relationships during write-time.

Other features
* rewrite `notstat` ProfileStrategy for performance.  it was previously untenable and not catching ephemeral :80 connections.  Now it samples proc filesystem for long enough and parses the hex characters later.
* remove unused noemodel classes.  We will add them as needed, instead of premature optimizing
* removed profile caching by service name.  Functionality too difficult to preserve at this point for unknown benefit.
* feature: add --seeds-only cli arg to perform discover only on the seed nodes passed in (and rewrite inventory initialization to respect --seeds-only)
* refactor: provider.profile() takes Node instead of address<str>
 feature: add script to curl endpoints