### PR TITLE
Differentiate node_name/name and service_name/app_name

### DIFF
--- a/astrolabe/database.py
+++ b/astrolabe/database.py
@@ -45,7 +45,8 @@ def _neomodel_to_node(platdb_node: platdb.PlatDBNode) -> Node:
         containerized=False,  # I don't know what else to put here
         from_hint=False,  # No hints in the sandbox for now
         address=platdb_node.address,
-        service_name=platdb_node.name,
+        service_name=platdb_node.app_name,
+        node_name=platdb_node.name,
         warnings=platdb_node.profile_warnings,
         errors=platdb_node.profile_errors,
         _profile_timestamp=platdb_node.profile_timestamp,
@@ -69,7 +70,8 @@ def save_node(node: Node) -> Node:
         protocol = node.protocol.ref
 
     props = {
-        'name': node.service_name,
+        'name': node.node_name,
+        'app_name': node.service_name,
         'address': node.address,
         'profile_strategy_name': node.profile_strategy_name,
         'protocol': protocol,

--- a/astrolabe/node.py
+++ b/astrolabe/node.py
@@ -68,6 +68,7 @@ class Node:
     containerized: bool = False
     from_hint: bool = False
     address: str = None
+    node_name: str = None
     service_name: str = None
     aliases: List[str] = field(default_factory=list)  # such as DNS names
     _profile_timestamp: Optional[datetime] = None

--- a/astrolabe/platdb.py
+++ b/astrolabe/platdb.py
@@ -238,6 +238,7 @@ class PlatDBNetworkNode(PlatDBNode):
     __abstract_node__ = True
     """Base class for nodes with network properties."""
     name = StringProperty()
+    app_name = StringProperty()
     address = StringProperty(required=True)
     protocol = StringProperty()
     protocol_multiplexor = StringProperty()

--- a/astrolabe/plugins/export_graphviz.py
+++ b/astrolabe/plugins/export_graphviz.py
@@ -45,8 +45,6 @@ class ExporterGraphviz(exporters.ExporterInterface):
                                     f"{GRAPHVIZ_RANKDIR_LEFT_TO_RIGHT} = \"Left-to-Right\", "
                                     f"{GRAPHVIZ_RANKDIR_TOP_TO_BOTTOM}=\"Top-to-Bottom\", "
                                     f"\"{GRAPHVIZ_RANKDIR_AUTO}\" automatically exports for best orientation")
-        argparser.add_argument('--highlight-services', nargs='+', metavar='SERVICE',
-                               help='A list of services to highlight in graphviz.')
         argparser.add_argument('--node-include-provider', action='store_true', default=False,
                                help='Include the provider in node names (e.g. "myservice (AWS))')
 
@@ -124,9 +122,6 @@ def _compile_digraph(node_ref: str, node: Node, blocking_from_top: bool = True) 
 
 
 def _compile_edge(parent_name: str, child: Node, child_name: str, child_blocking_from_top: bool) -> None:
-    parent_or_child_is_highlighted = (constants.ARGS.export_graphviz_highlight_services and
-                                      any(parent_name.startswith(name) or child_name.startswith(name)
-                                          for name in constants.ARGS.export_graphviz_highlight_services))
     edge_str = f"{parent_name}.{child.protocol.ref}.{child_name}"
     if edge_str not in edges_compiled:
         defunct = child.warnings.get('DEFUNCT')
@@ -135,7 +130,6 @@ def _compile_edge(parent_name: str, child: Node, child_name: str, child_blocking
         edge_style += ',dotted,filled' if defunct else ''
         edge_color = 'red' if child.errors else 'darkorange' if defunct else ''
         edge_color += ':blue' if child.from_hint else ''
-        edge_color += 'yellow:black:yellow' if parent_or_child_is_highlighted else ''
         edge_weight = '3' if defunct or child.from_hint else None
         errs_warns = ','.join({**child.errors, **child.warnings, **({'HINT': True} if child.from_hint else {})})
         label = f"{child.protocol.ref}{' (' + errs_warns + ')' if errs_warns else ''}"
@@ -154,7 +148,10 @@ def _compile_node(node: Node, name: str, blocking_from_top: bool) -> None:
 
 
 def _node_name(node: Node, node_ref: str) -> str:
-    name = node.service_name or f"UNKNOWN\n({node_ref})"
+    if node.service_name and node.node_name:
+        name = f"{node.service_name}_{node.node_name}"
+    else:
+        name = f"UNKNOWN\n({node_ref})"
     clean_name = exporters.clean_service_name(name)
     if constants.ARGS.export_graphviz_node_include_provider:
         clean_name = clean_name + f" ({node.provider})"

--- a/astrolabe/plugins/export_mermaid.py
+++ b/astrolabe/plugins/export_mermaid.py
@@ -211,6 +211,6 @@ def _compile_node(node: Node, name: str, mermaid_graph: MermaidGraph) -> None:
 
 def _node_name(node: Node) -> str:
     name = node.service_name or "UNKNOWN"
-    clean_name = exporters.clean_service_name(name)
+    clean_name = exporters.clean_service_name(f"{name}-{node.node_name}")
     clean_name = f"{clean_name}-{node.provider}"
     return clean_name

--- a/astrolabe/plugins/export_text.py
+++ b/astrolabe/plugins/export_text.py
@@ -38,8 +38,9 @@ def build_flat_services(tree_node: node.Node) -> None:
         return
 
     for child in children.values():
-        relationship = f"{tree_node.service_name or 'UNKNOWN'} --[{child.protocol.ref}]--> " \
-                       f"{child.service_name or child.address} ({child.protocol_mux})"
+        relationship = (f"{tree_node.service_name or 'UNKNOWN'} ({tree_node.node_name}) "
+                        f"--[{child.protocol.ref}:{child.protocol_mux}]--> "
+                        f"{child.service_name or child.address} ({child.node_name})")
         if relationship not in flat_relationships:
             flat_relationships[relationship] = (tree_node, child)
         build_flat_services(child)

--- a/examples/example_app.astrolabe.conf
+++ b/examples/example_app.astrolabe.conf
@@ -3,11 +3,11 @@ timeout = 180
 ssh-concurrency = 10
 ssh-name-command = echo $SANDBOX_APP_NAME
 ; aws provider
-aws-service-name-tag = App
+aws-app-name-tag = App
 aws-tag-filters = [Environment=sandbox1]
 ; k8s provider
 k8s-namespace = default
 k8s-label-selectors = [environment=dev]
-k8s-service-name-label = app
+k8s-app-name-label = app
 ; export
 export-ascii-verbose

--- a/examples/generate_pynapple_conf.sh
+++ b/examples/generate_pynapple_conf.sh
@@ -33,12 +33,12 @@ timeout = 180
 ssh-concurrency = 10
 ssh-name-command = echo \$SANDBOX_APP_NAME
 ; aws provider
-aws-service-name-tag = App
+aws-app-name-tag = App
 aws-tag-filters = [Environment=sandbox1]
 ; k8s provider
 k8s-namespace = default
 k8s-label-selectors = [environment=dev]
-k8s-service-name-label = app
+k8s-app-name-label = app
 ; export
 export-ascii-verbose
 EOL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,8 @@ def tree_stubbed_with_child(tree_stubbed, node_fixture) -> Dict[str, Node]:
 @pytest.fixture
 def tree_named(tree):
     """single node tree fixture - where the node has the service_name field filled out"""
-    list(tree.values())[0].service_name = 'dummy'
+    list(tree.values())[0].node_name = 'dummy_node'
+    list(tree.values())[0].service_name = 'dummy_service'
 
     return tree
 

--- a/tests/plugins/test_export_ascii.py
+++ b/tests/plugins/test_export_ascii.py
@@ -52,7 +52,7 @@ async def test_export_tree_case_seed(tree_stubbed, capsys):
     captured = capsys.readouterr()
 
     # assert
-    assert f"\n{seed.service_name} [{seed.protocol_mux}]\n" == captured.out
+    assert f"\n{seed.service_name} [{seed.node_type.name}] ({seed.provider}:{seed.node_name})\n" == captured.out
 
 
 @pytest.mark.asyncio
@@ -68,8 +68,8 @@ async def test_export_tree_case_child(tree_stubbed_with_child, capsys):
 
     # assert
     expected = ("\n"
-                f"{seed.service_name} [{seed.protocol_mux}]\n"
-                f" └--{child.protocol.ref}--> {child.service_name} [port:{child.protocol_mux}]\n")
+                f"{seed.service_name} [{seed.node_type.name}] ({seed.provider}:{seed.node_name})\n"
+                f" └--{child.protocol.ref}--> {child.service_name} [{child.node_type.name}] ({child.provider}:{child.node_name})\n")  # noqa: E501
     assert expected == captured.out
 
 
@@ -126,8 +126,8 @@ async def test_export_tree_case_child_errors(error, tree_stubbed_with_child, cap
     captured = capsys.readouterr()
 
     # assert
-    assert f" └--{child.protocol.ref}--? \x1b[31m{{ERR:{error}}} \x1b[0m{child.address} [port:{child.protocol_mux}]" \
-           in captured.out
+    expected = f" └--{child.protocol.ref}--? \x1b[31m{{ERR:{error}}} \x1b[0m{child.address} [{child.node_type.name}] ({child.provider}:{child.node_name})"  # noqa: E501
+    assert expected in captured.out
 
 
 @pytest.mark.asyncio
@@ -224,14 +224,13 @@ async def test_export_tree_case_merged_nodes(tree_stubbed_with_child, capsys):
     redundant_child = replace(child, address='asdf-zxc', protocol_mux='some_other_mux')
     _fake_database.connect_nodes(seed, redundant_child)
     # - we have to capture this now because export_tree will mutate these objects!
-    expected_merged_mux = f"{child.protocol_mux},{redundant_child.protocol_mux}"
 
     # act
     await _helper_export_tree_with_timeout(tree_stubbed_with_child)
     captured = capsys.readouterr()
 
     # assert
-    assert f"--> {child.service_name} [port:{expected_merged_mux}]" in captured.out
+    assert f"--> {child.service_name} [{child.node_type.name}] ({child.provider}:{child.node_name})" in captured.out
 
 
 ## TODO: Commenting test, for now.  This is a fairly complex display feature ... when ascii is no longer

--- a/tests/plugins/test_export_ascii.py
+++ b/tests/plugins/test_export_ascii.py
@@ -69,7 +69,7 @@ async def test_export_tree_case_child(tree_stubbed_with_child, capsys):
     # assert
     expected = ("\n"
                 f"{seed.service_name} [{seed.node_type.name}] ({seed.provider}:{seed.node_name})\n"
-                f" └--{child.protocol.ref}--> {child.service_name} [{child.node_type.name}] ({child.provider}:{child.node_name})\n")  # noqa: E501
+                f" └--{child.protocol.ref}--> {child.service_name} [{child.node_type.name}] ({child.provider}:{child.node_name})\n")  # noqa: E501  pylint:disable=line-too-long
     assert expected == captured.out
 
 
@@ -126,7 +126,7 @@ async def test_export_tree_case_child_errors(error, tree_stubbed_with_child, cap
     captured = capsys.readouterr()
 
     # assert
-    expected = f" └--{child.protocol.ref}--? \x1b[31m{{ERR:{error}}} \x1b[0m{child.address} [{child.node_type.name}] ({child.provider}:{child.node_name})"  # noqa: E501
+    expected = f" └--{child.protocol.ref}--? \x1b[31m{{ERR:{error}}} \x1b[0m{child.address} [{child.node_type.name}] ({child.provider}:{child.node_name})"  # noqa: E501  pylint:disable=line-too-long
     assert expected in captured.out
 
 

--- a/tests/plugins/test_export_mermaid.py
+++ b/tests/plugins/test_export_mermaid.py
@@ -48,7 +48,7 @@ def test_export_tree_case_node_has_service_name(tree_named):
     # arrange
     node = tree_named[list(tree_named)[0]]
     node.set_profile_timestamp()
-    node_id = f"{node.service_name}-{node.provider}"
+    node_id = f"{node.service_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree_named).splitlines()
@@ -61,7 +61,7 @@ def test_export_tree_case_node_no_service_name(tree):
     """single node - not from hint, no service name, no children, no errs/warns"""
     # arrange
     node = tree[list(tree)[0]]
-    node_id = f"UNKNOWN-{node.provider}"
+    node_id = f"UNKNOWN-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree).splitlines()
@@ -75,7 +75,7 @@ def test_export_tree_case_node_is_database(tree_named):
     # arrange
     node = list(tree_named.values())[0]
     node.protocol = replace(node.protocol, is_database=True)
-    node_id = f"{node.service_name}-{node.provider}"
+    node_id = f"{node.service_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree_named).splitlines()
@@ -89,7 +89,7 @@ def test_export_tree_case_node_is_containerized(tree_named):
     # arrange
     node = list(tree_named.values())[0]
     node.containerized = True
-    node_id = f"{node.service_name}-{node.provider}"
+    node_id = f"{node.service_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree_named).splitlines()
@@ -103,7 +103,7 @@ def test_export_tree_case_node_warns(tree_named):
     # arrange
     node = list(tree_named.values())[0]
     node.warnings = {'FOO': True}
-    node_id = f"{node.service_name}-{node.provider}"
+    node_id = f"{node.service_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree_named).splitlines()
@@ -117,7 +117,7 @@ def test_export_tree_case_node_errors(tree_named):
     # arrange
     node = list(tree_named.values())[0]
     node.errors = {'FOO': True}
-    node_id = f"{node.service_name}-{node.provider}"
+    node_id = f"{node.service_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree_named).splitlines()
@@ -131,7 +131,7 @@ def test_export_tree_case_node_defunct(tree_named):
     # arrange
     node = list(tree_named.values())[0]
     node.warnings = {'DEFUNCT': True}
-    node_id = f"{node.service_name}-{node.provider}"
+    node_id = f"{node.service_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree_named).splitlines()
@@ -146,7 +146,7 @@ def test_export_tree_case_node_name_cleaned(tree):
     node = list(tree.values())[0]
     node.service_name = '"foo:bar#baz"'
     cleaned_name = "foo_bar_baz"
-    node_id = f"{cleaned_name}-{node.provider}"
+    node_id = f"{cleaned_name}-{node.node_name}-{node.provider}"
 
     # act
     output_lines = export_mermaid.export_tree(tree).splitlines()

--- a/tests/plugins/test_export_text.py
+++ b/tests/plugins/test_export_text.py
@@ -11,5 +11,7 @@ def test_export_tree(tree_stubbed_with_child, capsys, patch_database):  # pylint
     child = list(_fake_database.get_connections(parent).values())[0]
 
     # assert
-    assert f"{parent.service_name} --[{child.protocol.ref}]--> {child.service_name} ({parent.protocol_mux})" \
+    assert (f"{parent.service_name} ({parent.node_name})"
+            f" --[{child.protocol.ref}:{child.protocol_mux}]--> "
+            f"{child.service_name} ({child.node_name})") \
            in captured.out


### PR DESCRIPTION
### Node.node_name and PlatDBNetworkNode.app_name
After the last refactor - we lost the unique Applications in the neomodel database.  This is because we were limited in astrolabe to only having `Node.address` (correlated to `PlatDBNode.address`) and `Node.service_name` (correlated to `PlatDBNode.name`.  This was a problem specifically for k8s services because we needed the k8s service name (`sandbox1-pynapple2-lb`) and the k8s service ipaddress (`172.x.x.x`) now that we are looking up CoreDNS 172 ipaddresses, but we lost the actual applicatiopn name `pynapple1` for example - so we needed a new field to put this in.

Here we have added `Node.node_name` and `PlatDBNetworkNode.app_name`.  We are now using `Node.service_name` only to hold the actual `Application` name that will be turned into a noemodel Application node.  

Since we are differentiating the name of the actual Node, such as an ec2 instance id (e.g. `i-128v3h098f`) or k8s deployment name (`sandbox1-pynapple2-lb`) and the name of the service/app it runs (`pynapple1`, etc) we needed to refactor of how these values are passed around and used - and the end result here is not likely to be the final result of how we want to handle all cases.  But at least we are now able to create the `Application` neomodel nodes correctly based off the of the name of the application

<img width="891" alt="image" src="https://github.com/user-attachments/assets/8ffd7177-5404-452d-bcd1-42c462a32f23" />

### Changes
* add Node.node_name to astrolabe.node.Node
* add PlatDBNetworkNode.app_name in platdb model
* Node.node_name -> PlatDBNode.name
* Node.service_name -> PlatDBNode.app_name
* refactor respective cli arg names
* inventory AWS resources with app_name/service_name tags
* inventory k8s resources with service_name/app_name