### PR TITLE
feature: k8s support multiple namespace (exclude system nss)

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -18,3 +18,7 @@ pylint:
     - no-else-return                # prefer multiple return statements
     - redefined-outer-name          # pytest fixture
   source-roots: .
+
+pyflakes:
+  disable:
+    - F999  # Unused global variable

--- a/examples/generate_pynapple_conf.sh
+++ b/examples/generate_pynapple_conf.sh
@@ -36,7 +36,6 @@ ssh-name-command = echo \$SANDBOX_APP_NAME
 aws-app-name-tag = App
 aws-tag-filters = [Environment=sandbox1]
 ; k8s provider
-k8s-namespace = default
 k8s-label-selectors = [environment=dev]
 k8s-app-name-label = app
 ; export


### PR DESCRIPTION
## Feature: Support Multiple Namespace
Previously astrolabe only supported 1 namespace in 1 k8s cluster.  This is not a rich feature, in that we don't track resource namespaces in the databases.  This is an MVP feature that now allows discovery across namespaces.  We are also excluding many system and common plugin namespaces by default.  