### PR TITLE
Improvements and Bug Fixes from Sandbox2

### DIFF
--- a/astrolabe.d/Netstat.yaml
+++ b/astrolabe.d/Netstat.yaml
@@ -2,25 +2,26 @@
 type: "ProfileStrategy"
 description: "Discovered TCP connections by reading netstat output"
 name: "Netstat"
-providers: ["ssh", "k8s"]
+#providers: ["ssh", "k8s"]
+providers: ["ssh"]
 protocol: "TCP"
 providerArgs:
     shell_command: |
         # pre-requisties
-        which netstat >/dev/null || exit
+        command -v netstat >/dev/null || exit
 
         # determine listening ports on this instance
         listening_ports=$(netstat -lnt | awk '{print $4}' | awk -F: '{print $NF}' | grep '[0-9]' | sort | uniq | tr '\n' '|')
 
         # get connections on ports we are interested in
-        netstat -ant | awk '$5 ~ /:(3306|9042|9160|11211|5432|6379|80)$/ {print}' |
+        netstat -ant | awk '$5 ~ /:(3306|9042|9160|11211|5432|6379|80|443)$/ {print}' |
 
         # filter TCP responses - we only want originating requests this filters out HTTP server response to
         # clients on ephemeral ports which happen to be in our list of ports of interest
         awk '$4 !~ /:('"$listening_ports"')$/ {print $5}' |
 
         # exclude if self is the dest
-        grep -v $(hostname | sed 's/ip-//' | tr '-' '.') |
+        grep -v $(getent hosts $(head -n 1 /proc/sys/kernel/hostname | awk '{print $1}') 2>/dev/null | awk '{print $1}' || echo "127.0.0.1") |
 
         # only take 1 server per port
         tr ':' ' ' | sort -k2 | uniq | awk 'BEGIN{print "mux address"};$1$2!=uniqid{print $2,$1;uniqie=$1$2}'
@@ -30,6 +31,7 @@ childProvider:
         5432: "aws"
         6379: "aws"
         80: "k8s"
+        443: "k8s"
     default: "aws"
 rendererArgs:
     promviz:

--- a/astrolabe.d/Notstat.yaml
+++ b/astrolabe.d/Notstat.yaml
@@ -2,13 +2,14 @@
 type: "ProfileStrategy"
 description: "Discover TCP connections by reading /proc/net/tcp filesystem"
 name: "Notstat"
-providers: ["ssh", "k8s"]
+#providers: ["ssh", "k8s"]
+providers: ["k8s"]
 protocol: "TCP"
 providerArgs:
     shell_command: |
         # pre-requisites
         # if netstat is installed - let the Netstat profile strategy handle profiling
-        which netstat >/dev/null && exit
+        command -v netstat >/dev/null && exit
         
         # Function to sample /proc/net/tcp for a specified duration
         # Capturing only the essential information for connection identification
@@ -27,6 +28,8 @@ providerArgs:
             while [ $(date +%s) -lt $end_time ]; do
                 # Only grab local address, remote address, and state (columns 2, 3, 4)
                 awk 'NR>1 {print $2, $3, $4}' /proc/net/tcp >> "$output_file"
+                # Also check tcp6 for IPv4-mapped addresses (common in Docker)
+                awk 'NR>1 {print $2, $3, $4}' /proc/net/tcp6 >> "$output_file" 2>/dev/null
             done
         }
         
@@ -52,9 +55,22 @@ providerArgs:
                 rem_ip_hex=$(echo $rem | cut -d: -f1)
                 rem_port_hex=$(echo $rem | cut -d: -f2)
         
-                # Convert hex IP to decimal IP
-                local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$local_ip_hex" | cut -c7-8)" 0x"$(echo "$local_ip_hex" | cut -c5-6)" 0x"$(echo "$local_ip_hex" | cut -c3-4)" 0x"$(echo "$local_ip_hex" | cut -c1-2)")
-                rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$rem_ip_hex" | cut -c7-8)" 0x"$(echo "$rem_ip_hex" | cut -c5-6)" 0x"$(echo "$rem_ip_hex" | cut -c3-4)" 0x"$(echo "$rem_ip_hex" | cut -c1-2)")
+                # Check if this is from tcp6 and an IPv4-mapped address
+                if [ ${#local_ip_hex} -gt 8 ]; then
+                    # This is from tcp6 - check if it's an IPv4-mapped address
+                    if [ "${local_ip_hex:0:24}" = "0000000000000000FFFF0000" ]; then
+                        # IPv4-mapped address - extract the IPv4 part
+                        local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${local_ip_hex:24:2}" 0x"${local_ip_hex:26:2}" 0x"${local_ip_hex:28:2}" 0x"${local_ip_hex:30:2}")
+                        rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${rem_ip_hex:24:2}" 0x"${rem_ip_hex:26:2}" 0x"${rem_ip_hex:28:2}" 0x"${rem_ip_hex:30:2}")
+                    else
+                        # Skip true IPv6 addresses
+                        continue
+                    fi
+                else
+                    # Convert hex IP to decimal IP
+                    local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$local_ip_hex" | cut -c7-8)" 0x"$(echo "$local_ip_hex" | cut -c5-6)" 0x"$(echo "$local_ip_hex" | cut -c3-4)" 0x"$(echo "$local_ip_hex" | cut -c1-2)")
+                    rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$rem_ip_hex" | cut -c7-8)" 0x"$(echo "$rem_ip_hex" | cut -c5-6)" 0x"$(echo "$rem_ip_hex" | cut -c3-4)" 0x"$(echo "$rem_ip_hex" | cut -c1-2)")
+                fi
         
                 # Convert hex port to decimal port
                 local_port_dec=$(printf "%d\n" 0x$local_port_hex)
@@ -83,11 +99,11 @@ providerArgs:
         # Process the data in one go
         echo "$ALL_CONNECTIONS" | 
             # get connections on ports we are interested in
-            awk '$2 ~ /:(3306|9042|9160|11211|5432|6379|80)$/ {print}' |
+            awk '$2 ~ /:(3306|9042|9160|11211|5432|6379|80|443)$/ {print}' |
             # filter TCP responses - we only want originating requests
             awk '$1 !~ /:('"$LISTENING_PORTS"')$/ {print $2}' |
             # exclude if self is the dest
-            grep -v $(hostname -i) |
+            grep -v $(getent hosts $(head -n 1 /proc/sys/kernel/hostname | awk '{print $1}') 2>/dev/null | awk '{print $1}' || echo "127.0.0.1") |
             # only take 1 server per port
             tr ':' ' ' | sort -k2 | uniq | 
             awk 'BEGIN{print "mux address"};$1$2!=uniqid{print $2,$1;uniqid=$1$2}'
@@ -97,6 +113,7 @@ childProvider:
         5432: "aws"
         6379: "aws"
         80: "k8s"
+        443: "k8s"
     default: "aws"
 rendererArgs:
     promviz:

--- a/astrolabe/cli_args.py
+++ b/astrolabe/cli_args.py
@@ -72,8 +72,16 @@ def parse_args(registered_exporter_refs: List[str]) -> (configargparse.Namespace
                                  'e.g. "ssh:10.0.0.42" or "k8s:widget-machine-5b5bc8f67f-2qmkp')
     discover_p.add_argument('-S', '--seeds-only', action='store_true',
                             help="Only profile seeds (and not inventoried nodes)")
+    discover_p.add_argument('-I', '--skip-inventory', action='store_true',
+                            help="Skip running the inventory process entirely")
+    discover_p.add_argument('-i', '--inventory-only', action='store_true',
+                            help="Only run the inventory process, not node profiling")
+    discover_p.add_argument('-H', '--skip-sidecar', action='store_true',
+                            help="Skip running the sidecar processes (including hostname lookups)")
     discover_p.add_argument('-t', '--timeout', type=int, default=180, metavar='TIMEOUT',
                             help='Timeout when discovering a node')
+    discover_p.add_argument('-T', '--connection-timeout', type=int, default=10, metavar='TIMEOUT',
+                            help='Timeout when establishing a connection to a node')
     discover_p.add_argument('-d', '--max-depth', type=int, default=100, metavar='DEPTH',
                             help='Max tree depth to discover')
     discover_p.add_argument('-X', '--disable-providers', nargs='+', default=[], metavar='PROVIDER',

--- a/astrolabe/plugins/provider_ssh.py
+++ b/astrolabe/plugins/provider_ssh.py
@@ -188,8 +188,9 @@ def _get_ssh_config_for_host(host: str) -> dict:
     try:
         with open(user_config_file, encoding="utf8") as open_file:
             ssh_config.parse(open_file)
-    except FileNotFoundError:
+    except FileNotFoundError as e:
         print("%s file could not be found. Aborting.", user_config_file)
+        print(e)
         sys.exit(1)
 
     return ssh_config.lookup(host)

--- a/astrolabe/profile_strategy.py
+++ b/astrolabe/profile_strategy.py
@@ -11,8 +11,9 @@ SPDX-License-Identifier: Apache-2.0
 
 import typing
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import List, Optional
+import yaml
 from yaml import safe_load_all
 
 from astrolabe import config, constants, logs, network
@@ -93,6 +94,14 @@ def init():
     _load_profile_strategies()
 
 
+def _safe_dump(obj):
+    """Safely dump object to YAML, handling problematic types."""
+    try:
+        return yaml.dump(asdict(obj), default_flow_style=False, sort_keys=False)
+    except ValueError:
+        return str(obj)
+
+
 def _load_profile_strategies():
     for file in config.get_config_yaml_files():
         with open(file, 'r', encoding='utf-8') as stream:
@@ -111,4 +120,4 @@ def _load_profile_strategies():
                     )
                     profile_strategies.append(pfs)
                     logs.logger.debug('Loaded ProfileStrategy:')
-                    logs.logger.debug(pfs)
+                    logs.logger.debug(_safe_dump(pfs))

--- a/astrolabe/providers.py
+++ b/astrolabe/providers.py
@@ -127,6 +127,10 @@ async def perform_inventory():
         logs.logger.info("Skipping inventory due to cli arg --seeds-only")
         return
 
+    if constants.ARGS.skip_inventory:
+        logs.logger.info("Skipping inventory due to cli arg --skip-inventory")
+        return
+
     for provider in [p for p in _provider_registry.get_registered_plugins()
                      if p.ref() not in (constants.ARGS.disable_providers or [])]:
         # provider: ProviderInterface
@@ -180,6 +184,7 @@ def _create_node_transport_from_profile_strategy_response_line(header_line: str,
 
     # field transforms/requirements
     if 'mux' not in fields:
+        logs.logger.error(fields)
         raise CreateNodeTransportException("protocol_mux missing from profile strategy results")
     if 'metadata' in fields:
         fields['metadata'] = dict(tuple(i.split('=') for i in fields['metadata'].split(',')))

--- a/tests/plugins/test_provider_aws.py
+++ b/tests/plugins/test_provider_aws.py
@@ -259,3 +259,43 @@ class TestProviderAWS:
         assert deployment_node is not None, f"DEPLOYMENT node with address={asg_name} should exist"
         assert not hasattr(deployment_node, 'service_name') or deployment_node.service_name is None, \
             "DEPLOYMENT node should not have service_name when tag is missing"
+
+    def test_inventory_load_balancers_missing_port(self, patch_database, cli_args_mock,
+                                                   mock_boto3_setup, mock_boto3_client,
+                                                   lb_dns_name, asg_name, public_ip):
+        """Test that the code handles a target group without a Port attribute"""
+        # Arrange
+        cli_args_mock.aws_app_name_tag = 'AppName'
+        cli_args_mock.aws_use_private_ips = False
+        provider = ProviderAWS()
+
+        # Modify the ELB client response to remove the Port from the target group
+        elb_client = provider.elb_client
+        elb_client.describe_target_groups.return_value = {
+            'TargetGroups': [{
+                'TargetGroupName': 'test-tg',
+                # Port is intentionally missing
+                'TargetGroupArn': 'arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/test-tg/73e2d6bc24d8a067'
+            }]
+        }
+
+        # Act
+        # This should not raise a KeyError if fixed correctly
+        provider._inventory_load_balancers()
+
+        # Assert
+        # Verify that the nodes were still created, even without a port
+        dns_lookup_nodes = dict(database.get_nodes_pending_dnslookup())
+        assert lb_dns_name in dns_lookup_nodes, "Traffic controller should still be created"
+
+        # Find the deployment node
+        deployment_node = database.get_node_by_address(asg_name)
+        assert deployment_node is not None, "Deployment node should still be created"
+
+        # Find the compute node using its IP address
+        compute_node = database.get_node_by_address(public_ip)
+        assert compute_node is not None, "Compute node should still be created"
+
+        # The compute node should have protocol_mux set to None or a default value
+        assert compute_node.protocol_mux is None or isinstance(compute_node.protocol_mux, int), \
+            "Compute node should have protocol_mux set to None or a default value"

--- a/tests/plugins/test_provider_aws.py
+++ b/tests/plugins/test_provider_aws.py
@@ -275,13 +275,13 @@ class TestProviderAWS:
             'TargetGroups': [{
                 'TargetGroupName': 'test-tg',
                 # Port is intentionally missing
-                'TargetGroupArn': 'arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/test-tg/73e2d6bc24d8a067'
+                'TargetGroupArn': 'arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/test-tg/73e2d6bc24d8'
             }]
         }
 
         # Act
         # This should not raise a KeyError if fixed correctly
-        provider._inventory_load_balancers()
+        provider._inventory_load_balancers()  # pylint:disable=protected-access
 
         # Assert
         # Verify that the nodes were still created, even without a port
@@ -299,3 +299,48 @@ class TestProviderAWS:
         # The compute node should have protocol_mux set to None or a default value
         assert compute_node.protocol_mux is None or isinstance(compute_node.protocol_mux, int), \
             "Compute node should have protocol_mux set to None or a default value"
+
+    @pytest.mark.parametrize("k8s_tag_key", [
+        'kubernetes.io/cluster',
+        'KubernetesCluster',
+        'k8s.io/cluster/',
+        'kubernetes:cluster',
+        'service.k8s.aws/stack',
+        'elbv2.k8s.aws/cluster',
+        'kubernetes-tag',
+        'kube-system',
+    ])
+    def test_k8s_tags_skip_node_creation(self, patch_database, cli_args_mock,
+                                         mock_boto3_setup, mock_boto3_client,
+                                         lb_dns_name, asg_name, public_ip, k8s_tag_key):
+        """Test that no nodes are created when Kubernetes tags are present on an ELB"""
+        # Arrange
+        cli_args_mock.aws_app_name_tag = 'AppName'
+        cli_args_mock.aws_use_private_ips = False
+        provider = ProviderAWS()
+        # Add Kubernetes tag to ELB
+        elb_client = provider.elb_client
+        elb_client.describe_tags.return_value = {
+            'TagDescriptions': [{
+                'Tags': [{'Key': k8s_tag_key, 'Value': 'test-value'}]
+            }]
+        }
+
+        # Act
+        provider._inventory_load_balancers()  # pylint:disable=protected-access
+
+        # Assert
+        # Check that no TRAFFIC_CONTROLLER node is created for the LB DNS name
+        dns_lookup_nodes = dict(database.get_nodes_pending_dnslookup())
+        assert lb_dns_name not in dns_lookup_nodes, \
+            f"Traffic controller with DNS name {lb_dns_name} should not be created for a Kubernetes ELB"
+
+        # Check that no DEPLOYMENT node is created for the ASG
+        deployment_node = database.get_node_by_address(asg_name)
+        assert deployment_node is None, \
+            f"DEPLOYMENT node with address={asg_name} should not be created for a Kubernetes ELB"
+
+        # Check that no COMPUTE node is created for the EC2 instance
+        compute_node = database.get_node_by_address(public_ip)
+        assert compute_node is None, \
+            f"COMPUTE node with address={public_ip} should not be created for a Kubernetes ELB"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,57 @@
+import pytest
+from astrolabe import constants
+from astrolabe.main import main
+
+
+@pytest.fixture(autouse=True)
+def setup_common_mocks(mocker):
+    """Setup all common mocks needed for most tests."""
+    # Mock database functions
+    mocker.patch('astrolabe.database.init')
+    mocker.patch('astrolabe.database.close')
+
+    # Mock plugin loading
+    mocker.patch('astrolabe.plugin_core.import_plugin_classes')
+    mocker.patch('astrolabe.profile_strategy.init')
+    mocker.patch('astrolabe.providers.register_providers')
+    mocker.patch('astrolabe.exporters.register_exporters')
+    mocker.patch('astrolabe.exporters.parse_exporter_args')
+    mocker.patch('astrolabe.exporters.get_exporter_by_ref')
+    mocker.patch('astrolabe.providers.parse_provider_args')
+    mocker.patch('astrolabe.providers.cleanup_providers')
+    mocker.patch('astrolabe.providers.perform_inventory')
+    # Mock os.makedirs to prevent filesystem changes
+    mocker.patch('os.makedirs')
+
+    # Mock exporters
+    mocker.patch('astrolabe.plugins.export_json.dump')
+
+    # Yield to test
+    yield
+
+    # Reset any global state
+    if hasattr(constants, 'ARGS'):
+        del constants.ARGS
+
+
+def test_inventory_only_skips_discover(mocker):
+    """Test that if --inventory-only is set, discover.discover() is not called."""
+    # Setup mocks specific to this test
+    mock_discover = mocker.patch('astrolabe.discover.discover')
+
+    # Setup mock args
+    constants.ARGS = mocker.MagicMock(
+        command='discover',
+        inventory_only=True,
+        disable_providers=[],
+        output=['ascii'],
+        debug=False,
+        quiet=False
+    )
+    mocker.patch('configargparse.ArgumentParser.parse_known_args', return_value=(constants.ARGS, []))
+
+    # Execute main function
+    main()
+
+    # Assert discover.discover was not called
+    mock_discover.assert_not_called()


### PR DESCRIPTION
Deploying into sandbox2 dev environment.  Identified several issues.  Here we are:
### Netstat/Notstat Profile Strategies
Some POSIX compatabilities:
- using `command -v` over `which`
- reading from `proc.../hostname` over `hostname -i`
- reading from `/proc/tcp/tcp6` in additionn to `/proc/tcp/tcp6`
- Add profiling of port 443 connections

### AWS Inventory
- Do not inventory k8s application ELBs (they are inventoried via provider_k8s)
- Do not inventory labmda's behind ELBs (FFF (foggy future feature))

### CLI Args Added
- `--skip-inventory`
- `--inventory-only`
- `--skip-sidecar` (skip hostname lookups)
- `--connection-timeout` (differentiate from --timeout now for profiling/etc)
- `--seeds-only` now includes descendents of seeds

### Misc
- main.py always prints ascii even if discovery fails