### PR TITLE
Feature/node types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,49 +1,44 @@
 ### OSS RELEASE FOLLOW UPS
-* [ ] code
-  * [ ] astrolabe CI/CD move to github
-  * [ ] corelib/platdb CI/CD move to github
-* [ ] oss
+  * [x] rename astrolabe-oss/corelib repo to platdb?
+  * [x] pynapple repo filter and port over to example repo
+  * [x] example app - terraform repo
   * [ ] demo video for README
-  * [ ] rename astrolabe-oss/corelib repo to platdb?
-  * [ ] pynapple repo filter and port over to example repo
-  * [ ] example app - terraform repo
-  * [ ] move cartographer to private repo
   * [ ] credit image: https://commons.wikimedia.org/wiki/File:Astrolabe.png
 
 ### BUGS
 * [x] `cli_args.py`: configargparse doesn't let parse lists in config file! (NOV 2024)
 * [ ] cannot save nodes with no address or alias (used to be able to save nodes with protocol_mux only, this died during the neo4j refactor)
-* [ ] `timeout` seems to be no timeout for profiling/discovery any more.  non-ssh-able seeds will hang `discover` forever!
+
+### RETHINK
+* [ ] Rethink:  ProfileStrategy: RemoteProfile vs LocalProfile?
+* [ ] Rethink:  address/name.  For example, should "address" be the DNS name for a load balancer?  What is address exactly?
+* [ ] Rethink: hould application be a "tag" not a Node?
+* [ ] Rethink: Unknown/Null node types.
+* [ ] Rethink: provider determination - shotgun lookup instead of configured?
+* [ ] Rethink: export, json.  Entire graph vs seed?  Seed for export?  Last run?
+* [ ] Rethink: NodeTransport.  Do we even need it anymore?
 
 ### FEATURES/IMPROVEMENTS
 * [x] FEATURE - export mermaid (NOV 2024)
-* [ ] UNKNOWN platdb node type!
-* [ ] Rename discover/profile?
-  * [ ] rename ProfileStrategy -> RemoteDiscoveryScript
-* [ ] should "address" be the DNS name for a load balancer?
-* [ ] should application be a "tag" not a Node?
-* [ ] seed auto discovery
-* [ ] ProfileStrategies
-  * [ ] a queuing system
-* [ ] Providers
-  * [ ] c7n provider
- * [ ] ProfileStrategy::childProviders: rewrite provider lookup to be a shotgun approach instead of configured?
- * [ ] EXPORTERS: optionally export entire graph or just tree from passed in seeds 
-
-### REFACTORS/TESTS
-* [ ] `node.py`: remove Node.children field (should be unused logically - cruft remains mainly in tests)
-* [ ] `node.py`: get ride of NodeTransport?
+* [ ] Seed auto discovery based on inventory 
 * [ ] `database.py`: neo4j vars should be looked up in ENV vars as well.  (Can we do this by convention for all args?)
-* [ ] `discover.py`: tests for idempotency runs
+* [ ] `discover.py`: is it idempotent right now?
 * [ ] `database.py`: get rid of database.node_is* funcs, these shouldn't require a database call
+
+### CRUFT
+* [ ] `node.py`: remove Node.children field (should be unused logically - cruft remains mainly in tests)
 * [ ] `node.py`: Node.profile_stategy_name is just for logging/audit, move to somethign like -> Node.discovery_audit
 * [ ] `node.py`: move discover.create_node() -> node.create_node()
 * [ ] `database.py`: need tests for logic/transforms, etc
+
+### BIG RELEASES
+* [ ] `temporalness` - introduce the concept of time/when to solve for changing infra
 
 ### Documentation:
 * [ ] Profile Strategies - examples
 * [ ] Writing Custom Plugins/Providers - example
 * [ ] Env Vars
+* [ ] Install doc
 
 ### FOR OSS RELEASE (NOV 2024)
 * [x] code
@@ -66,3 +61,7 @@
 * [x] profile(.., pfs, ...) -> profile(.., pfs[], ...)
 * [x] rename profile_strategy_used_name -> profile_strategy_name
 
+### DESIGN PHILOSOPHY
+* Convention over Configuration
+* Defensive Programming (log and proceed)
+* Allow incomplet

--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,7 @@
 
 ### FEATURES/IMPROVEMENTS
 * [x] FEATURE - export mermaid (NOV 2024)
+* [ ] k8s - add k8s_cluster as a node_attribute
 * [ ] Seed auto discovery based on inventory 
 * [ ] `database.py`: neo4j vars should be looked up in ENV vars as well.  (Can we do this by convention for all args?)
 * [ ] `discover.py`: is it idempotent right now?
@@ -31,8 +32,12 @@
 * [ ] `node.py`: move discover.create_node() -> node.create_node()
 * [ ] `database.py`: need tests for logic/transforms, etc
 
-### BIG RELEASES
+### BIG ONE: TEMPORALNESS
 * [ ] `temporalness` - introduce the concept of time/when to solve for changing infra
+
+### BIG ONE: DEFENSIVENESS
+* [ ] `defensiveness` - mux not expected from profile results
+* [ ] `definsiveness` - how do we handle ALL exceptions in discovery/profiling?  Throw non-exiting exception & log?
 
 ### Documentation:
 * [ ] Profile Strategies - examples

--- a/astrolabe.d/Netstat.yaml
+++ b/astrolabe.d/Netstat.yaml
@@ -28,11 +28,8 @@ providerArgs:
 childProvider:
     type: "matchPort"
     matches:
-        5432: "aws"
-        6379: "aws"
-        80: "k8s"
-        443: "k8s"
-    default: "aws"
-rendererArgs:
-    promviz:
-
+        5432: ["aws", "RESOURCE"]
+        6379: ["aws", "RESOURCE"]
+        80: ["k8s", "COMPUTE"]
+        443: ["k8s", "COMPUTE"]
+    default: ["k8s", "UNKNOWN"]

--- a/astrolabe.d/Notstat.yaml
+++ b/astrolabe.d/Notstat.yaml
@@ -99,7 +99,7 @@ providerArgs:
         # Process the data in one go
         echo "$ALL_CONNECTIONS" | 
             # get connections on ports we are interested in
-            awk '$2 ~ /:(3306|9042|9160|11211|5432|6379|80|443)$/ {print}' |
+            # awk '$2 ~ /:(3306|9042|9160|11211|5432|6379|80|443)$/ {print}' |
             # filter TCP responses - we only want originating requests
             awk '$1 !~ /:('"$LISTENING_PORTS"')$/ {print $2}' |
             # exclude if self is the dest
@@ -110,11 +110,8 @@ providerArgs:
 childProvider:
     type: "matchPort"
     matches:
-        5432: "aws"
-        6379: "aws"
-        80: "k8s"
-        443: "k8s"
-    default: "aws"
-rendererArgs:
-    promviz:
-
+        5432: ["aws", "RESOURCE"]
+        6379: ["aws", "RESOURCE"]
+        80: ["k8s", "COMPUTE"]
+        443: ["k8s", "COMPUTE"]
+    default: ["k8s", "UNKNOWN"]

--- a/astrolabe/cli_args.py
+++ b/astrolabe/cli_args.py
@@ -64,14 +64,14 @@ def parse_args(registered_exporter_refs: List[str]) -> (configargparse.Namespace
         sub_p.add_argument('--debug', action='store_true', help='Log debug output to stderr')
         sub_p.add_argument('-c', '--config-file', is_config_file=True, metavar='FILE',
                            help='Specify a config file path')
+        sub_p.add_argument('-S', '--seeds-only', action='store_true',
+                           help="Only profile seeds (and not inventoried nodes)")
 
     # discover command args
     discover_p.add_argument('-s', '--seeds', nargs="+", required=True, metavar='SEED',
                             help='Seed host(s) to begin discovering viz. an IP address or hostname.  '
                                  'Must be in the format: "provider:address".  '
                                  'e.g. "ssh:10.0.0.42" or "k8s:widget-machine-5b5bc8f67f-2qmkp')
-    discover_p.add_argument('-S', '--seeds-only', action='store_true',
-                            help="Only profile seeds (and not inventoried nodes)")
     discover_p.add_argument('-I', '--skip-inventory', action='store_true',
                             help="Skip running the inventory process entirely")
     discover_p.add_argument('-i', '--inventory-only', action='store_true',

--- a/astrolabe/node.py
+++ b/astrolabe/node.py
@@ -23,6 +23,7 @@ class NodeType(Enum):
     RESOURCE = 'RESOURCE'
     DEPLOYMENT = 'DEPLOYMENT'
     TRAFFIC_CONTROLLER = 'TRAFFIC_CONTROLLER'
+    UNKNOWN = 'UNKNOWN'
     __type__: str = 'NodeType'  # for json serialization/deserialization
 
 
@@ -37,7 +38,7 @@ class NodeTransport:
         protocol: the protocol of the NodeTransport
         protocol_mux: the protocol multiplexer (port for TCP, nsq topic:channel for NSQ).
         address: the node address.  e.g. "IP address" or k8s pod name
-        from_hint: wether the node transport is from a Hint
+        from_hint: whether the node transport is from a Hint
         debug_identifier: like the "name" of the service - but it is not the official name and only used for debug/logs
         num_connections: optional num_connections.  if 0, node will be marked as "DEFUNCT"
         metadata: optional key-value pairs of metadata.  not used by core but useful to custom plugins
@@ -67,6 +68,7 @@ class Node:
     protocol_mux: str = None
     containerized: bool = False
     from_hint: bool = False
+    public_ip: bool = False
     address: str = None
     ipaddrs: Optional[List[str]] = None
     node_name: str = None

--- a/astrolabe/plugin_core.py
+++ b/astrolabe/plugin_core.py
@@ -19,6 +19,7 @@ import configargparse
 from termcolor import colored
 
 import astrolabe.plugins
+from astrolabe import logs
 
 
 def import_plugin_classes():
@@ -106,6 +107,7 @@ class PluginFamilyRegistry:
             p_obj = plugin()
             asyncio.get_event_loop().run_until_complete(p_obj.init_async())
             self._plugin_registry[plugin.ref()] = p_obj
+            logs.logger.debug("Registered plugin: %s (%s)", plugin.ref(), plugin)
 
     def cleanup_plugins(self):
         loop = asyncio.get_event_loop()
@@ -118,6 +120,7 @@ class PluginFamilyRegistry:
         except KeyError as exc:
             print(colored(f"Attempted to load invalid plugin: {ref}", 'red'))
             print(colored(exc, 'yellow'))
+            print(colored(f"Available plugins: {','.join(self._plugin_registry)}"))
             sys.exit(1)
 
     def get_registered_plugin_refs(self) -> List[str]:

--- a/astrolabe/plugins/provider_k8s.py
+++ b/astrolabe/plugins/provider_k8s.py
@@ -164,7 +164,8 @@ class ProviderKubernetes(ProviderInterface):
                     protocol_mux=service.spec.ports[0].target_port,
                     profile_strategy_name='_profile_k8s_service',
                     provider='k8s',
-                    from_hint=False
+                    from_hint=False,
+                    node_type=NodeType(NodeType.COMPUTE)
                 )
                 node_transports.append(node_transport)
                 logs.logger.debug("Found %d profile results for %s, profile strategy: \"%s\"..",

--- a/astrolabe/plugins/provider_www.py
+++ b/astrolabe/plugins/provider_www.py
@@ -1,0 +1,70 @@
+"""
+Module Name: provider_www
+
+Description:
+Provider for looking up info regarding public internet IPs
+
+License:
+SPDX-License-Identifier: Apache-2.0
+"""
+from typing import Optional
+import ipinfo
+
+from astrolabe.providers import ProviderInterface
+from astrolabe import constants
+
+
+class ProviderWWW(ProviderInterface):
+    @staticmethod
+    def ref() -> str:
+        return 'www'
+
+    def __init__(self):
+        self.handler = None
+
+    async def init_async(self):
+        """Initialize the ipinfo handler asynchronously"""
+        # Get token directly from constants.ARGS when needed
+        token = getattr(constants.ARGS, 'www_ipinfo_token', None)
+        # Initialize the ipinfo client
+        self.handler = ipinfo.getHandler(token)
+        # The handler is now ready to use
+
+    @staticmethod
+    def register_cli_args(argparser):
+        argparser.add_argument('--ipinfo-token', metavar='TOKEN',
+                               help='API token for ipinfo.io lookups')
+
+    async def lookup_name(self, address: str, _) -> Optional[str]:
+        """
+        Look up information about a public IP address using ipinfo.io
+        Returns a formatted string: "{org} ({region}, {country})"
+
+        Args:
+            address: The IP address to look up
+            connection: Optional connection object (not used for this provider)
+
+        Returns:
+            A formatted string with organization and location info, or None if lookup fails
+        """
+        try:
+            # Check if handler is initialized
+            if self.handler is None:
+                return None
+
+            # The ipinfo library handles caching, rate limiting, and retries
+            details = self.handler.getDetails(address)
+
+            # Get organization, region and country information
+            org = getattr(details, 'org', 'Unknown')
+            region = getattr(details, 'region', 'Unknown')
+            country = getattr(details, 'country_name', None) or getattr(details, 'country', 'Unknown')
+
+            # Format the result string
+            result = f"{org} ({region}, {country})"
+
+            return result
+
+        except Exception:  # pylint:disable=broad-exception-caught
+            # Return None in case of any error
+            return None

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'boto3~=1.16',
         'configargparse~=1.2',
         'coolname~=2.0',
+        'ipinfo~=5.1',
         'faker>=4.1',
         'kubernetes_asyncio~=30.3',
         'paramiko~=3.4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,12 +56,12 @@ def protocol_mock(mocker, dummy_protocol_ref) -> MagicMock:
 
 @pytest.fixture
 def profile_strategy_fixture() -> ProfileStrategy:
-    return ProfileStrategy('', '', None, '', {'shell_command': 'foo'}, {}, {}, {})
+    return ProfileStrategy('', '', None, '', {'shell_command': 'foo'}, {}, {})
 
 
 @pytest.fixture
 def ps_mock(protocol_fixture, mocker, mock_provider_ref) -> MagicMock:
-    """it is a required fixture to include, whether or not it is used explicitly, in or to mock profile"""
+    """it is a required fixture to include, whether or not it is used explicitly, in order to mock profile"""
     ps_mock = mocker.patch('astrolabe.profile_strategy.ProfileStrategy', autospec=True)
     mocker.patch('astrolabe.profile_strategy.profile_strategies', [ps_mock])
     ps_mock.name = 'FAKE'
@@ -69,6 +69,7 @@ def ps_mock(protocol_fixture, mocker, mock_provider_ref) -> MagicMock:
     ps_mock.protocol = protocol_fixture
     ps_mock.provider_args = {}
     ps_mock.providers = [mock_provider_ref]
+    ps_mock.determine_child_provider.return_value = ('fak', 'FAKE')
 
     return ps_mock
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from astrolabe import providers, node, constants
+from astrolabe.node import NodeType
 
 
 @pytest.fixture(autouse=True)
@@ -118,8 +119,8 @@ def test_parse_profile_strategy_response_case_mux_only(ps_mock):
     protocol_mux = 'foo'
     profile_strategy_response = f"mux\n{protocol_mux}"
     provider = 'FAKE'
-    ps_mock.determine_child_provider.return_value = provider
-    expected = [node.NodeTransport(ps_mock.name, provider, ps_mock.protocol, protocol_mux)]
+    ps_mock.determine_child_provider.return_value = (provider, NodeType.UNKNOWN)
+    expected = [node.NodeTransport(ps_mock.name, provider, ps_mock.protocol, protocol_mux, node_type=NodeType.UNKNOWN)]
 
     # act/assert
     res = providers.parse_profile_strategy_response(profile_strategy_response, '', ps_mock)
@@ -133,9 +134,9 @@ def test_parse_profile_strategy_response_case_all_fields(ps_mock):
     profile_strategy_response = f"mux address id conns metadata\n" \
                                 f"{mux} {address} {_id} {conns} {metadata}"
     provider = 'FAKE'
-    ps_mock.determine_child_provider.return_value = provider
+    ps_mock.determine_child_provider.return_value = (provider, NodeType.UNKNOWN)
     expected = [node.NodeTransport(ps_mock.name, provider, ps_mock.protocol, mux, address,
-                                   False, _id, int(conns), {metadata_1_key: metadata_1_val})]
+                                   False, _id, int(conns), {metadata_1_key: metadata_1_val}, NodeType.UNKNOWN)]
 
     # act/assert
     res = providers.parse_profile_strategy_response(profile_strategy_response, '', ps_mock)

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -14,7 +14,7 @@ from astrolabe.platdb import (Neo4jConnection,
 
 @pytest.fixture(scope="module")
 def neo4j_connection():
-    uri = "bolt://localhost:7687"
+    uri = "bolt://localhost:17687"
     username = "neo4j"
     password = "guruai11"
     driver = Neo4jConnection(uri=uri, auth=(username, password))
@@ -55,11 +55,7 @@ def mock_complex_graph(neo4j_connection):
 
     # Connections
     deployment1.computes.connect(compute1)
-    compute1.deployment.connect(deployment1)
     deployment1.application.connect(app1)
-    app1.deployments.connect(deployment1)
 
     deployment2.computes.connect(compute2)
-    compute2.deployment.connect(deployment2)
     deployment2.application.connect(app2)
-    app2.deployments.connect(deployment2)

--- a/tests_integration/neo4j_ephemeral_db/docker-compose.yml
+++ b/tests_integration/neo4j_ephemeral_db/docker-compose.yml
@@ -5,5 +5,5 @@ services:
     environment:
       - NEO4J_AUTH=neo4j/guruai11
     ports:
-      - "7687:7687"
-      - "7474:7474" # Port is for Neo4j UI in web browser
+      - "17687:7687"
+#      - "7474:7474" # Port is for Neo4j UI in web browser


### PR DESCRIPTION
## Main Features
### Add UNKNOWN NodeType
It is basically a Compute node with no downstream.  This is not a long term solution b/c we do not yet know how to "promote" from Unknown NodeTtype to another nodetype using python's `neomodel`.  Although common w/ neo4j... It is not a native functionality to change "types" with neomodel.  This suffices for now.

### Specify NodeType in ProfileStrategy
Also not a long term solution, ultimately we are going to guess the NodeType based on standards, and allow an override somehow per client configuration.  For now we need to specify it in the ProfileStrategy `yaml` in order to differentiate in the visual graph.

### Add `.public_ip` to Node
Although we can derive this after the fact, we now store this property in `astrolabe.Node` and respective neomodel nodes.  Our module assumes that special IPs are non-public (not necessarily true).

### `provider_www`
We have a new provider: `www`.  This is a neat trick to be able to use `ipinfo.io` in order to do reverse ip lookup on public ip's to get the geo region/org/etc.  