### PR TITLE
Multi Cluster Support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,12 @@
+### CURRENT
+* [ ] include ipaddress array field in the platdb database
+
 ### OSS RELEASE FOLLOW UPS
-  * [x] rename astrolabe-oss/corelib repo to platdb?
-  * [x] pynapple repo filter and port over to example repo
-  * [x] example app - terraform repo
-  * [ ] demo video for README
-  * [ ] credit image: https://commons.wikimedia.org/wiki/File:Astrolabe.png
+* [x] rename astrolabe-oss/corelib repo to platdb?
+* [x] pynapple repo filter and port over to example repo
+* [x] example app - terraform repo
+* [ ] demo video for README
+* [ ] credit image: https://commons.wikimedia.org/wiki/File:Astrolabe.png
 
 ### BUGS
 * [x] `cli_args.py`: configargparse doesn't let parse lists in config file! (NOV 2024)

--- a/astrolabe.d/Netstat.yaml
+++ b/astrolabe.d/Netstat.yaml
@@ -13,8 +13,11 @@ providerArgs:
         # determine listening ports on this instance
         listening_ports=$(netstat -lnt | awk '{print $4}' | awk -F: '{print $NF}' | grep '[0-9]' | sort | uniq | tr '\n' '|')
 
-        # get connections on ports we are interested in
-        netstat -ant | # awk '$5 ~ /:(3306|9042|9160|11211|5432|6379|80|443)$/ {print}' |
+        # get connections
+        netstat -ant | 
+
+        # only on ports we are interested in
+        # awk '$5 ~ /:(3306|9042|9160|11211|5432|6379|80|443)$/ {print}' |
 
         # filter TCP responses - we only want originating requests this filters out HTTP server response to
         # clients on ephemeral ports which happen to be in our list of ports of interest

--- a/astrolabe.d/Notstat.yaml
+++ b/astrolabe.d/Notstat.yaml
@@ -60,16 +60,16 @@ providerArgs:
                     # This is from tcp6 - check if it's an IPv4-mapped address
                     if [ "${local_ip_hex:0:24}" = "0000000000000000FFFF0000" ]; then
                         # IPv4-mapped address - extract the IPv4 part
-                        local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${local_ip_hex:24:2}" 0x"${local_ip_hex:26:2}" 0x"${local_ip_hex:28:2}" 0x"${local_ip_hex:30:2}")
-                        rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${rem_ip_hex:24:2}" 0x"${rem_ip_hex:26:2}" 0x"${rem_ip_hex:28:2}" 0x"${rem_ip_hex:30:2}")
+                        local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${local_ip_hex:30:2}" 0x"${local_ip_hex:28:2}" 0x"${local_ip_hex:26:2}" 0x"${local_ip_hex:24:2}")
+                        rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${rem_ip_hex:30:2}" 0x"${rem_ip_hex:28:2}" 0x"${rem_ip_hex:26:2}" 0x"${rem_ip_hex:24:2}")
                     else
                         # Skip true IPv6 addresses
                         continue
                     fi
                 else
                     # Convert hex IP to decimal IP
-                    local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$local_ip_hex" | cut -c7-8)" 0x"$(echo "$local_ip_hex" | cut -c5-6)" 0x"$(echo "$local_ip_hex" | cut -c3-4)" 0x"$(echo "$local_ip_hex" | cut -c1-2)")
-                    rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"$(echo "$rem_ip_hex" | cut -c7-8)" 0x"$(echo "$rem_ip_hex" | cut -c5-6)" 0x"$(echo "$rem_ip_hex" | cut -c3-4)" 0x"$(echo "$rem_ip_hex" | cut -c1-2)")
+                    local_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${local_ip_hex:6:2}" 0x"${local_ip_hex:4:2}" 0x"${local_ip_hex:2:2}" 0x"${local_ip_hex:0:2}")
+                    rem_ip_dec=$(printf "%d.%d.%d.%d\n" 0x"${rem_ip_hex:6:2}" 0x"${rem_ip_hex:4:2}" 0x"${rem_ip_hex:2:2}" 0x"${rem_ip_hex:0:2}")
                 fi
         
                 # Convert hex port to decimal port
@@ -110,8 +110,10 @@ providerArgs:
 childProvider:
     type: "matchPort"
     matches:
-        5432: ["aws", "RESOURCE"]
-        6379: ["aws", "RESOURCE"]
-        80: ["k8s", "COMPUTE"]
-        443: ["k8s", "COMPUTE"]
-    default: ["k8s", "UNKNOWN"]
+        5432: ["aws", "RESOURCE"]   # PostreSQL
+        6379: ["aws", "RESOURCE"]   # REDIS
+        80: ["k8s", "COMPUTE"]      # w3
+        443: ["k8s", "COMPUTE"]     # w3
+        8080: ["k8s", "COMPUTE"]    # w3
+        8883: ["k8s", "COMPUTE"]    # MQTT
+    default: ["k8s", "COMPUTE"]

--- a/astrolabe/database.py
+++ b/astrolabe/database.py
@@ -53,7 +53,8 @@ def _neomodel_to_node(platdb_node: platdb.PlatDBNode) -> Node:
         errors=platdb_node.profile_errors,
         _profile_timestamp=platdb_node.profile_timestamp,
         _profile_lock_time=platdb_node.profile_lock_time,
-        node_type=class_to_node[platdb_node.__class__]
+        node_type=class_to_node[platdb_node.__class__],
+        cluster=platdb_node.cluster
     )
 
     if hasattr(platdb_node, 'ipaddrs'):
@@ -86,7 +87,8 @@ def save_node(node: Node) -> Node:
         'provider': node.provider,
         'public_ip': node.public_ip,
         'profile_warnings': node.warnings,
-        'profile_errors': node.errors
+        'profile_errors': node.errors,
+        'cluster': node.cluster
     }
 
     # NOTE Node.node_type defaults to COMPUTE

--- a/astrolabe/database.py
+++ b/astrolabe/database.py
@@ -88,7 +88,8 @@ def save_node(node: Node) -> Node:
         'public_ip': node.public_ip,
         'profile_warnings': node.warnings,
         'profile_errors': node.errors,
-        'cluster': node.cluster
+        'cluster': node.cluster,
+        'ipaddrs': node.ipaddrs
     }
 
     # NOTE Node.node_type defaults to COMPUTE
@@ -141,7 +142,6 @@ def _merge_resource(node: Node, props: dict) -> platdb.PlatDBNode:
 
 def _merge_traffic_controller(node: Node, props: dict) -> platdb.PlatDBNode:
     props['dns_names'] = node.aliases
-    props['ipaddrs'] = node.ipaddrs
     tctl = platdb.TrafficController.create_or_update(props)[0]
 
     return tctl
@@ -348,7 +348,7 @@ def get_nodes_unprofiled(since: datetime) -> Dict[str, Node]:
             node = _neomodel_to_node(pdb_node)
             ref = f"{node.provider}:{node.node_type}:{node.address or ','.join(node.aliases)}"
             results[ref] = node
-
+    logs.logger.debug("Found %d unprofiled nodes.", len(results))
     return results
 
 

--- a/astrolabe/discover.py
+++ b/astrolabe/discover.py
@@ -197,6 +197,12 @@ async def _discovery_algo(node_ref: str, node: Node, ancestors: List[str], provi
         node.errors['CONNECT_SKIPPED'] = True
         return {}
 
+    # QUALIFY NODE FOR PROVIDER
+    if not await provider.qualify_node(node):
+        logs.logger.warning("Node %s (%s) does not quality for provider: %s (%s)",
+                            node_ref, node.address, provider.ref(), provider.cluster())
+        return {}
+
     # OPEN CONNECTION
     logs.logger.debug("Opening connection: %s", node.address)
     conn = await asyncio.wait_for(provider.open_connection(node.address), constants.ARGS.connection_timeout)
@@ -329,7 +335,7 @@ async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str
                 logs.logger.debug("Excluded profile result: `%s`. Reason: protocol_mux_skipped",
                                   node_transport.protocol_mux)
                 continue
-            child_ref, child = create_node(node_transport, provider)
+            child_ref, child = await create_node(node_transport, provider)
             if child:
                 children[child_ref] = child
 

--- a/astrolabe/discover.py
+++ b/astrolabe/discover.py
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
-import ipaddress
 import traceback
 
 from typing import Dict, List, Optional
@@ -21,7 +20,7 @@ from astrolabe import database, profile_strategy, network, constants, logs, obfu
 from astrolabe.constants import CURRENT_RUN_TIMESTAMP
 from astrolabe.profile_strategy import ProfileStrategy
 from astrolabe.providers import ProviderInterface
-from astrolabe.node import Node, NodeTransport, merge_node
+from astrolabe.node import Node, merge_node, create_node
 
 # An internal cache which prevents astrolabe from re-profiling a Compute node of the same Application
 # that has already been profiled on a different address. We may not want this "feature" going forward
@@ -276,6 +275,7 @@ async def _lookup_service_name(node: Node, provider: providers.ProviderInterface
 # pylint:disable=too-many-locals
 async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str, Node]:  # noqa: C901, MC0001
     provider_ref = node.provider
+    provider = providers.get_provider_by_ref(provider_ref)
     service_name = node.service_name
 
     # COMPILE PROFILE STRATEGIES
@@ -290,7 +290,7 @@ async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str
             continue
         profile_strategies.append(pfs)
     tasks.append(asyncio.wait_for(
-        providers.get_provider_by_ref(provider_ref).profile(node, profile_strategies, connection),
+        provider.profile(node, profile_strategies, connection),
         timeout=constants.ARGS.timeout
     ))
 
@@ -329,7 +329,7 @@ async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str
                 logs.logger.debug("Excluded profile result: `%s`. Reason: protocol_mux_skipped",
                                   node_transport.protocol_mux)
                 continue
-            child_ref, child = create_node(node_transport)
+            child_ref, child = create_node(node_transport, provider)
             if child:
                 children[child_ref] = child
 
@@ -340,51 +340,3 @@ async def _profile_node(node: Node, node_ref: str, connection: type) -> Dict[str
     nonexcluded_children = {ref: n for ref, n in children.items() if n.provider not in constants.ARGS.disable_providers}
 
     return nonexcluded_children
-
-
-def create_node(node_transport: NodeTransport) -> (str, Optional[Node]):
-    if constants.ARGS.obfuscate:
-        node_transport = obfuscate.obfuscate_node_transport(node_transport)
-    if node_transport.provider in constants.ARGS.disable_providers:
-        logs.logger.info("Skipping discovery for node: %s:%s due to disabled provider: %s",
-                         node_transport.provider, node_transport.address, node_transport.provider)
-        return "", None
-
-    public_ip = _is_public_ip(node_transport.address)
-    node = Node(
-        profile_strategy_name=node_transport.profile_strategy_name,
-        protocol=node_transport.protocol,
-        protocol_mux=node_transport.protocol_mux,
-        provider='www' if public_ip else node_transport.provider,
-        containerized=providers.get_provider_by_ref(node_transport.provider).is_container_platform(),
-        from_hint=node_transport.from_hint,
-        public_ip=public_ip,
-        address=node_transport.address,
-        service_name=node_transport.debug_identifier if node_transport.from_hint else None,
-        metadata=node_transport.metadata,
-        node_type=node_transport.node_type
-    )
-
-    # warnings/errors
-    if not node_transport.address or 'null' == node_transport.address:
-        node.errors['NULL_ADDRESS'] = True
-    if 0 == node_transport.num_connections:
-        node.warnings['DEFUNCT'] = True
-
-    node_ref = '_'.join(str(x) for x in [node_transport.protocol.ref, node_transport.address,
-                        node_transport.protocol_mux, node_transport.debug_identifier]
-                        if x is not None)
-    return node_ref, node
-
-
-def _is_public_ip(ip_string):
-    try:
-        ip = ipaddress.ip_address(ip_string)
-        if ip.is_unspecified:
-            # for our implementation we are considering unknown as "public"
-            return True
-        if ip.is_reserved or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
-            return False
-        return not ip.is_private
-    except ValueError:
-        return False

--- a/astrolabe/node.py
+++ b/astrolabe/node.py
@@ -8,11 +8,13 @@ License:
 SPDX-License-Identifier: Apache-2.0
 """
 from enum import Enum
+import ipaddress
 from typing import Dict, Optional, List
-from dataclasses import dataclass, field, asdict, is_dataclass, fields
+from dataclasses import dataclass, field, asdict, is_dataclass, fields, replace
 from datetime import datetime, timezone
 import json
 
+from astrolabe import constants, obfuscate, logs
 
 database_muxes = ['3306', '9160', '5432', '6379', '11211']
 
@@ -81,6 +83,7 @@ class Node:
     errors: dict = field(default_factory=dict)
     metadata: dict = field(default_factory=dict)
     node_type: NodeType = NodeType(NodeType.COMPUTE)
+    cluster: Optional[str] = None
     __type__: str = 'Node'  # for json serialization/deserialization
 
     def __str__(self):
@@ -163,3 +166,53 @@ def merge_node(copyto_node: Node, copyfrom_node: Node) -> None:
         # Only copy if the source value is not None, empty string, empty dict, or empty list
         if copyfrom_value is not None and copyfrom_value != "" and copyfrom_value != {} and copyfrom_value != []:
             setattr(copyto_node, attr_name, copyfrom_value)
+
+
+def create_node(node_transport: NodeTransport, provider: 'providers.ProviderInterface') -> (str, Optional[Node]):  # noqa: F821  # Avoid circular import  # pylint:disable=line-too-long
+    if constants.ARGS.obfuscate:
+        obfsc_mux = obfuscate.obfuscate_protocol_mux(node_transport.protocol_mux)
+        node_transport = replace(node_transport, protocol_mux=obfsc_mux)
+    if node_transport.provider in constants.ARGS.disable_providers:
+        logs.logger.info("Skipping discovery for node: %s:%s due to disabled provider: %s",
+                         node_transport.provider, node_transport.address, node_transport.provider)
+        return "", None
+
+    public_ip = _is_public_ip(node_transport.address)
+    node = Node(
+        profile_strategy_name=node_transport.profile_strategy_name,
+        protocol=node_transport.protocol,
+        protocol_mux=node_transport.protocol_mux,
+        provider='www' if public_ip else node_transport.provider,
+        containerized=provider.is_container_platform(),
+        from_hint=node_transport.from_hint,
+        public_ip=public_ip,
+        address=node_transport.address,
+        service_name=node_transport.debug_identifier if node_transport.from_hint else None,
+        metadata=node_transport.metadata,
+        node_type=node_transport.node_type,
+        cluster=provider.cluster()
+    )
+
+    # warnings/errors
+    if not node_transport.address or 'null' == node_transport.address:
+        node.errors['NULL_ADDRESS'] = True
+    if 0 == node_transport.num_connections:
+        node.warnings['DEFUNCT'] = True
+
+    node_ref = '_'.join(str(x) for x in [node_transport.protocol.ref, node_transport.address,
+                        node_transport.protocol_mux, node_transport.debug_identifier]
+                        if x is not None)
+    return node_ref, node
+
+
+def _is_public_ip(ip_string):
+    try:
+        ip = ipaddress.ip_address(ip_string)
+        if ip.is_unspecified:
+            # for our implementation we are considering unknown as "public"
+            return True
+        if ip.is_reserved or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+            return False
+        return not ip.is_private
+    except ValueError:
+        return False

--- a/astrolabe/obfuscate.py
+++ b/astrolabe/obfuscate.py
@@ -7,14 +7,11 @@ Code for obfuscate service names during export
 License:
 SPDX-License-Identifier: Apache-2.0
 """
-
-from dataclasses import replace
 from typing import Dict
 
 import coolname
 import faker
 
-from astrolabe.node import NodeTransport
 _obfuscated_service_names: Dict[str, str] = {}
 _obfuscated_protocol_muxes: Dict[str, str] = {}
 
@@ -27,12 +24,7 @@ def obfuscate_service_name(service_name: str):
     return obfuscated_name
 
 
-def obfuscate_node_transport(node_transport: NodeTransport) -> NodeTransport:
-    obfuscated_protocol_mux = _obfuscate_protocol_mux(node_transport.protocol_mux)
-    return replace(node_transport, protocol_mux=obfuscated_protocol_mux)
-
-
-def _obfuscate_protocol_mux(protocol_mux: str) -> str:
+def obfuscate_protocol_mux(protocol_mux: str) -> str:
     if protocol_mux in _obfuscated_protocol_muxes:
         return _obfuscated_protocol_muxes[protocol_mux]
     if protocol_mux.isdigit():

--- a/astrolabe/platdb.py
+++ b/astrolabe/platdb.py
@@ -126,6 +126,7 @@ class PlatDBNode(StructuredNode):
     profile_strategy_name = StringProperty()
     provider = StringProperty()
     app_name = StringProperty()
+    cluster = StringProperty()
 
     # New fields to mirror `warnings` and `errors` in Astrolabe Node class
     profile_warnings = JSONProperty(default={})

--- a/astrolabe/platdb.py
+++ b/astrolabe/platdb.py
@@ -126,7 +126,6 @@ class PlatDBNode(StructuredNode):
     profile_strategy_name = StringProperty()
     provider = StringProperty()
     app_name = StringProperty()
-    cluster = StringProperty()
 
     # New fields to mirror `warnings` and `errors` in Astrolabe Node class
     profile_warnings = JSONProperty(default={})
@@ -201,10 +200,13 @@ class PlatDBNetworkNode(PlatDBNode):
     protocol = StringProperty()
     protocol_multiplexor = StringProperty()
     public_ip = BooleanProperty()
+    ipaddrs = ArrayProperty(StringProperty(), null=True)
+    cluster = StringProperty()
 
 
 class Deployment(PlatDBNetworkNode):
     name = StringProperty(unique_index=True)
+    cluster = StringProperty(required=True)
     deployment_type = StringProperty(choices={
         "aws_asg": "AWS Auto Scaling Group",
         "k8s_deployment": "K8s Deployment"})
@@ -240,7 +242,6 @@ class PlatDBDNSNode(PlatDBNetworkNode):
     __abstract_node__ = True
     address = StringProperty(unique_index=True, null=True, required=False)
     dns_names = ArrayProperty(StringProperty(), unique_index=True, null=True)
-    ipaddrs = ArrayProperty(StringProperty(), null=True)
 
     # pylint:disable=arguments-differ
     @classmethod

--- a/astrolabe/plugins/provider_aws.py
+++ b/astrolabe/plugins/provider_aws.py
@@ -201,6 +201,7 @@ class ProviderAWS(ProviderInterface):
                 lb_node = None
                 lb_address = lb['DNSName']
                 lb_name = lb['LoadBalancerName']
+                lb_vpc_ip = lb.get('VpcId') or lb.get('VPCId') or 'UNKNOWN'
                 listeners = self.elb_client.describe_listeners(LoadBalancerArn=lb['LoadBalancerArn'])['Listeners']
                 lb_port = listeners[0]['Port'] if listeners else None
                 tags_response = self.elb_client.describe_tags(ResourceArns=[lb['LoadBalancerArn']])
@@ -217,7 +218,8 @@ class ProviderAWS(ProviderInterface):
                         provider='aws',
                         protocol=PROTOCOL_TCP,
                         protocol_mux=lb_port,
-                        aliases=[lb_address]
+                        aliases=[lb_address],
+                        cluster=lb_vpc_ip
                     )
                     lb_node.set_profile_timestamp()
                     if lb_app_tag:
@@ -257,7 +259,8 @@ class ProviderAWS(ProviderInterface):
                                     protocol=PROTOCOL_TCP,
                                     protocol_mux=tg_port,
                                     provider='aws',
-                                    service_name=lb_app_tag
+                                    service_name=lb_app_tag,
+                                    cluster=lb_vpc_ip
                                 )
                                 asg_node.set_profile_timestamp()
                                 asg_nodes[f"ASG_{asg_name}"] = asg_node
@@ -281,7 +284,8 @@ class ProviderAWS(ProviderInterface):
                                 profile_strategy_name=INVENTORY_PROFILE_STRATEGY_NAME,
                                 protocol=PROTOCOL_TCP,
                                 protocol_mux=tg_port,
-                                provider='ssh'
+                                provider='ssh',
+                                cluster=lb_vpc_ip
                             )
                             ec2_node.set_profile_timestamp()
                             database.save_node(ec2_node)

--- a/astrolabe/plugins/provider_aws.py
+++ b/astrolabe/plugins/provider_aws.py
@@ -219,6 +219,7 @@ class ProviderAWS(ProviderInterface):
                         protocol_mux=lb_port,
                         aliases=[lb_address]
                     )
+                    lb_node.set_profile_timestamp()
                     if lb_app_tag:
                         lb_node.service_name = lb_app_tag
                     database.save_node(lb_node)
@@ -258,6 +259,7 @@ class ProviderAWS(ProviderInterface):
                                     provider='aws',
                                     service_name=lb_app_tag
                                 )
+                                asg_node.set_profile_timestamp()
                                 asg_nodes[f"ASG_{asg_name}"] = asg_node
                                 database.save_node(asg_node)
                                 database.connect_nodes(lb_node, asg_node)
@@ -281,6 +283,7 @@ class ProviderAWS(ProviderInterface):
                                 protocol_mux=tg_port,
                                 provider='ssh'
                             )
+                            ec2_node.set_profile_timestamp()
                             database.save_node(ec2_node)
                             database.connect_nodes(asg_node, ec2_node)
                             logs.logger.info("Inventoried 1 AWS EC2 node: %s", ec2_node.debug_id())

--- a/astrolabe/providers.py
+++ b/astrolabe/providers.py
@@ -15,7 +15,6 @@ from typing import List, Optional
 import configargparse
 
 from astrolabe import constants, logs
-from astrolabe.network import Hint
 from astrolabe.node import Node, NodeTransport
 from astrolabe.plugin_core import PluginInterface, PluginFamilyRegistry
 from astrolabe.profile_strategy import ProfileStrategy
@@ -38,6 +37,14 @@ class ProviderInterface(PluginInterface):
         :return:
         """
         return False
+
+    def cluster(self) -> Optional[str]:
+        """
+        Returns the data center cluster associated with the provider, if any
+
+        :return: Optional[str]: The cluster name as a string if associated, otherwise None.
+        """
+        return None
 
     async def inventory(self) -> None:
         """
@@ -88,7 +95,7 @@ class ProviderInterface(PluginInterface):
         del address, connection
         return None
 
-    async def take_a_hint(self, hint: Hint) -> List[NodeTransport]:
+    async def take_a_hint(self, hint: 'network.Hint') -> List[NodeTransport]:    # noqa: F821  # Avoid circular import
         """
         Takes a hint, looks up an instance of service in the provider, and returns a NodeTransport representing the
         Node discovered in the Provider. Default response when subclassing will be a no-op, which allows provider

--- a/astrolabe/providers.py
+++ b/astrolabe/providers.py
@@ -52,6 +52,14 @@ class ProviderInterface(PluginInterface):
         """
         return None
 
+    async def qualify_node(self, node: Node) -> bool:
+        """
+        Determines whether a given node "belongs" to this provider and can be profiled, etc
+
+        :return: bool: True if the node qualifies, false if no.
+        """
+        return node is not None
+
     async def open_connection(self, address: str) -> Optional[type]:
         """
         Optionally open a connection which can then be passed into lookup_name() and discover()

--- a/tests/plugins/test_provider_k8s.py
+++ b/tests/plugins/test_provider_k8s.py
@@ -3,13 +3,19 @@
 import pytest
 
 from kubernetes_asyncio.client.models import V1PodList, V1ServiceList, V1Pod, V1Service
-from astrolabe.plugins.provider_k8s import ProviderKubernetes
+from astrolabe.plugins import provider_k8s
+from astrolabe.node import NodeType
+
+
+@pytest.fixture(autouse=True)
+def clear_pod_cache():
+    provider_k8s.pod_cache = {}
 
 
 @pytest.fixture
 def k8s_provider(mocker):
     """Returns a ProviderKubernetes instance with mocked API."""
-    provider = ProviderKubernetes()
+    provider = provider_k8s.ProviderKubernetes()
     provider.api = mocker.Mock()
     provider.api.list_service_for_all_namespaces = mocker.AsyncMock()
     provider.api.list_namespaced_pod = mocker.AsyncMock()
@@ -193,3 +199,77 @@ async def test_sidecar_respects_excluded_namespaces(
     # Assert
     # Verify pods were queried from the allowed namespace
     assert k8s_provider.ws_api.connect_get_namespaced_pod_exec.call_count == allowed
+
+
+@pytest.mark.parametrize('node_type,node_cluster,prov_cluster,qualifies', [
+    (NodeType.DEPLOYMENT, 'cluster1', 'cluster1', True),
+    (NodeType.DEPLOYMENT, 'cluster1', 'cluster2', False),
+    (NodeType.TRAFFIC_CONTROLLER, 'cluster1', 'cluster1', True),
+    (NodeType.TRAFFIC_CONTROLLER, 'cluster1', 'cluster2', False),
+    (NodeType.RESOURCE, 'doesntmatter', 'doesntmatter', False),
+    (NodeType.COMPUTE, 'cluster1', 'cluster1', True),
+])
+@pytest.mark.asyncio
+async def test_qualify_node_standard_paths(k8s_provider, node_fixture, prov_cluster,
+                                           node_cluster, node_type, qualifies):
+    """Test qualify_node for standard pathways"""
+    # Arrange
+    node_fixture.cluster = node_cluster
+    node_fixture.node_type = node_type
+    k8s_provider._cluster_name = prov_cluster  # pylint:disable=protected-access
+
+    # Act
+    provider_qualified = await k8s_provider.qualify_node(node_fixture)
+
+    # Assert
+    assert provider_qualified == qualifies
+
+
+@pytest.mark.parametrize('node_address,pod_cache,qualifies', [
+    (None, {'does_not_matter': 'does_not_matter'}, False),
+    ('foo', {'foo': 'bar'}, True),
+    ('foo', {'cats': 'dogs'}, False),
+    ('foo', {}, False)
+])
+@pytest.mark.asyncio
+async def test_qualify_node_check_pod_cache_podname(k8s_provider, node_fixture, node_address, pod_cache, qualifies):
+    """Check if we have cached the pod by name in our local cache.  We consider the pod name to be Node.address
+       in astrolabeland."""
+    # Arrange
+    node_fixture.cluster = None
+    node_fixture.node_type = NodeType.COMPUTE
+    node_fixture.address = node_address
+    node_fixture.ipaddrs = None
+    k8s_provider._cluster_name = 'does_not_matter'  # pylint:disable=protected-access
+    # don't be confused... setting pod cache on the module not the object!
+    provider_k8s.pod_cache = pod_cache
+
+    # Act
+    provider_qualified = await k8s_provider.qualify_node(node_fixture)
+
+    # Assert
+    assert provider_qualified == qualifies
+
+
+@pytest.mark.parametrize('node_ipaddrs,pod_cache_ip,qualifies', [
+    (None, 'does_not_matter', False),
+    (['1.2.3.4', '5,6,7,8'], '1.2.3.4', True),
+    (['1.2.3.4', '5,6,7,8'], '4.3.2.1', False),
+])
+@pytest.mark.asyncio
+async def test_qualify_node_check_pod_ips(k8s_provider, mocker, node_fixture, node_ipaddrs, pod_cache_ip, qualifies):
+    """Test qualify_cluster returns True and sets cluster name when cluster name exists."""
+    # Arrange
+    node_fixture.cluster = None
+    node_fixture.node_type = NodeType.COMPUTE
+    node_fixture.ipaddrs = node_ipaddrs
+    k8s_provider._cluster_name = 'does_not_matter'  # pylint:disable=protected-access
+    provider_k8s.pod_cache = {'a_pod': mocker.Mock(**{'status.pod_ip': pod_cache_ip})}
+    # ensure we don't check the pod cache by address/pod name
+    node_fixture.address = None
+
+    # Act
+    provider_qualified = await k8s_provider.qualify_node(node_fixture)
+
+    # Assert
+    assert provider_qualified == qualifies

--- a/tests/plugins/test_provider_k8s.py
+++ b/tests/plugins/test_provider_k8s.py
@@ -102,7 +102,7 @@ async def test_profile_k8s_service_respects_default_excluded_namespaces(
 @pytest.fixture
 def mock_pfs_response(mocker, k8s_provider):
     # Mock exec response to return a result
-    mocker.patch('astrolabe.plugins.provider_k8s.parse_profile_strategy_response', return_value=["mocked-result"])
+    mocker.patch('astrolabe.plugins.provider_k8s.parse_profile_strategy_response', return_value=[mocker.MagicMock()])
     k8s_provider.ws_api = mocker.Mock()
     k8s_provider.ws_api.connect_get_namespaced_pod_exec = mocker.AsyncMock(return_value="test response")
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -356,17 +356,17 @@ async def test_discover_case_cycle(tree, provider_mock, utcnow):
     # Invalid IP
     ("not-an-ip", False, "invalid IP format"),
 ])
-def test_create_node_ip_address_classification(mocker, ip_addr, expected_public, desc):
+def test_create_node_ip_address_classification(mocker, ip_addr, expected_public, desc, provider_mock):
     """Tests the IP address classification logic through the create_node method"""
     # arrange
     mocker.patch('astrolabe.discover.providers.get_provider_by_ref')
     nt = mocker.MagicMock(address=ip_addr)
 
     # act
-    _, node = discover.create_node(nt)
+    _, n = node.create_node(nt, provider_mock)
 
     # assert
-    assert node.public_ip == expected_public, f"public_ip flag wrong for {desc}: {ip_addr}"
+    assert n.public_ip == expected_public, f"public_ip flag wrong for {desc}: {ip_addr}"
 
 
 # def test_create_node_with_disabled_provider(mocker):

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from astrolabe import obfuscate, node
+from astrolabe import obfuscate
 
 
 def test_obfuscate_service_name():
@@ -23,16 +23,16 @@ def test_obfuscate_service_name():
 
 
 @pytest.mark.parametrize('real_mux,expect_mux_match', [('8080', '[0-9]+'), ('foobar', '[a-z]+#[a-z]+')])
-def test_obfuscate_node_transport_case_protocol_mux(real_mux, expect_mux_match, provider_mock):
+def test_obfuscate_protocol_mux(real_mux, expect_mux_match):
     """obfuscate twice to ensure consistent obfuscation"""
     # arrange
-    node_transport = node.NodeTransport('FAKE', provider_mock, 'FAKE', real_mux)
 
     # act
-    obfuscated_node_transport = obfuscate.obfuscate_node_transport(node_transport)
-    obfuscated_node_transport_two = obfuscate.obfuscate_node_transport(node_transport)
+    obfuscated_once = obfuscate.obfuscate_protocol_mux(real_mux)
+    obfuscated_twoce = obfuscate.obfuscate_protocol_mux(real_mux)
 
     # assert
-    assert obfuscated_node_transport.protocol_mux != real_mux
-    assert re.search(expect_mux_match, obfuscated_node_transport.protocol_mux)
-    assert obfuscated_node_transport == obfuscated_node_transport_two
+    assert obfuscated_once != real_mux
+    assert re.search(expect_mux_match, obfuscated_once)
+    assert re.search(expect_mux_match, obfuscated_twoce)
+    assert obfuscated_once == obfuscated_twoce

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -50,8 +50,8 @@ def mock_complex_graph(neo4j_connection):
     app2 = Application(**{'name': 'app2'}).save()
     compute1 = Compute(**create_mock_service('compute1')).save()
     compute2 = Compute(**create_mock_service('compute2')).save()
-    deployment1 = Deployment(**{'address': 'addy1'}).save()
-    deployment2 = Deployment(**{'address': 'addy2'}).save()
+    deployment1 = Deployment(**{'address': 'addy1', 'cluster': 'aws_vpc_id'}).save()
+    deployment2 = Deployment(**{'address': 'addy2', 'cluster': 'eks-cluster'}).save()
 
     # Connections
     deployment1.computes.connect(compute1)

--- a/tests_integration/test_platdb_ephemeral.py
+++ b/tests_integration/test_platdb_ephemeral.py
@@ -31,12 +31,14 @@ neo4j_db_fixtures = [
         "deployment_type": "aws_asg",
         "address": "1.2.3.4",
         "protocol": "TCP",
-        "protocol_multiplexor": "80"
+        "protocol_multiplexor": "80",
+        "cluster": "vpc-123f9d9"
     }, {
         "deployment_type": "k8s_deployment",
         "address": "5.6.7.8",
         "protocol": "HTTP",
-        "protocol_multiplexor": "443"
+        "protocol_multiplexor": "443",
+        "cluster": "eks-i-am-a-cluster"
     }),
     (Resource, {
         "name": "resource1",


### PR DESCRIPTION
## Multi Cluster Support
This adds "cluster" awareness to astrolabe Nodes.   

### cluster: an imperfect abstraction
`cluster` is currently a loose and imperfect abstraction for a private network and/or a kubernetes cluster and/or an AWS VPC.  In real life an EKS cluster is contained within a VPC... however in the current limited model of astrolabe's viewpoint these are different "clusters".

### cluster qualifification
`provider.qualify_node()` has been added.  During profile, nodes are now "qualified" by their provider.  This is so that we don't profile nodes from a different VPC and/or k8s cluster (for example) just because we retrieve them from the database to be profiled.  We run various checks agains the node to see if it is indeed a part of this runtime provider qualified with it's cluster before qualifying the node.

### Data persistence
`Node.cluster` <-> `PlatDBNode.cluster`

## MAJOR BUG FIX - Inerted IPADDRESS OCTETS
Introduced here: [054d208a0d47a71dffbc769602e09d96b9cf68e5](https://github.com/astrolabe-oss/astrolabe/commit/054d208a0d47a71dffbc769602e09d96b9cf68e5#diff-1c2acff4d4482b4360315ea998973bed7c9d04493d5783d5ddd1f5a16832674b)
 
During the above Notstat rewrite in order to include the `/proc/net/tcp6` filesystem... we rewrote the strategy for parsing the hex characters, and accidentally inverted the octets.  Making `1.2.3.4` look like `4.3.2.1`.  This inverted IP addresses for any profiled traffic.  This was very confusing and made normal intranet traffic like `172.29.10.224` look like multicast traffic such as `224.10.29.172` and worse it made it look like we were reaching out to the public internet even to various foreign contries and governments.  What a bug!

### Features
* Adds `ipaddrs` to PlatDBNode attributes